### PR TITLE
Make T component rerender on language change

### DIFF
--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -3652,9 +3652,9 @@
       }
     },
     "@transifex/native": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@transifex/native/-/native-0.1.0.tgz",
-      "integrity": "sha512-iUN6avhGKde4SjEb0F47Cd3w60geV6J+JU6S128oycp2JkPunyJ6nXB7nC1SlI07qIOafBFISZdCRmA9hTvb+Q==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@transifex/native/-/native-0.2.1.tgz",
+      "integrity": "sha512-3s01xox+MLVkXkGjkahG158eG7KqEfc182xIueUi3LsSdVj/epq+9efqXX3exQvKYXTSSDX6kQvfORvBpAbgJQ==",
       "dev": true,
       "requires": {
         "axios": "^0.19.2",
@@ -14909,14 +14909,14 @@
       }
     },
     "md5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
-      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
       "dev": true,
       "requires": {
-        "charenc": "~0.0.1",
-        "crypt": "~0.0.1",
-        "is-buffer": "~1.1.1"
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
       }
     },
     "md5.js": {

--- a/packages/react/src/T.jsx
+++ b/packages/react/src/T.jsx
@@ -1,36 +1,33 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import {
   t, onEvent, offEvent, LOCALE_CHANGED,
 } from '@transifex/native';
 
-function T(props) {
-  const { _str, _html, _inline } = props;
+function T({ _str, _html, _inline }) {
+  const [translation, setTranslation] = useState('');
 
   useEffect(() => {
-    onEvent(LOCALE_CHANGED, () => {});
-    return () => offEvent(LOCALE_CHANGED, () => {});
-  }, []);
+    function render() {
+      if (!_html) {
+        setTranslation(t(_str, { _html, _inline }));
+      } else {
+        const result = t(_str, {
+          _html,
+          _inline,
+          _escapeVars: true,
+        });
+        const parentProps = { dangerouslySetInnerHTML: { __html: result } };
+        const parent = _inline ? 'span' : 'div';
+        setTranslation(React.createElement(parent, parentProps));
+      }
+    }
+    render();
+    onEvent(LOCALE_CHANGED, render);
+    return () => { offEvent(LOCALE_CHANGED, render); };
+  }, [_str, _html, _inline]);
 
-  let translation = '';
-  let parent = null;
-  let parentProps = {};
-
-  if (!_html) {
-    translation = t(_str, {
-      ...props,
-    });
-  } else {
-    translation = t(_str, {
-      ...props,
-      _escapeVars: true,
-    });
-
-    parentProps = { dangerouslySetInnerHTML: { __html: translation } };
-    parent = _inline ? 'span' : 'div';
-  }
-
-  return parent ? React.createElement(parent, parentProps) : translation;
+  return translation;
 }
 
 T.defaultProps = {


### PR DESCRIPTION
During the rewrite to use `@transifex/native` instead of `@transifex/core`, the live re-render functionality was dropped. This PR reintroduces it.

I have tested this on a local project by copy-pasting the `src/T.jsx` file.