### PR TITLE
Handle plural strings from CDS

### DIFF
--- a/packages/native/src/utils.js
+++ b/packages/native/src/utils.js
@@ -64,3 +64,135 @@ export function normalizeLocale(locale) {
   }
   return normalizedLocale;
 }
+
+const PLURAL_RULES = ['zero', 'one', 'two', 'few', 'many', 'other'];
+
+function _consumePreamble(string) {
+  if (!(string.length > 1
+      && string[0] === '{'
+      && string[string.length - 1] === '}')
+  ) {
+    return [null, null];
+  }
+
+  // {cnt, plural, one {foo} other {foos}}
+  //  ^^^^^^^^^^^
+  const firstCommaPos = string.indexOf(',');
+  if (firstCommaPos === -1) { return [null, null]; }
+  const secondCommaPos = string.indexOf(',', firstCommaPos + 1);
+  if (secondCommaPos === -1) { return [null, null]; }
+
+  const varName = string.substring(1, firstCommaPos).trim();
+  const keyword = string
+    .substring(firstCommaPos + 1, secondCommaPos)
+    .trim();
+
+  // Make sure `keyword` is 'plural'
+  if (keyword !== 'plural') { return [null, null]; }
+
+  return [
+    varName,
+    string.substring(secondCommaPos + 1, string.length - 1).trim()];
+}
+
+function _consumeRule(string) {
+  // {cnt, plural, one {foo} other {foos}}
+  //              ^^^^^
+  const leftBracketPos = string.indexOf('{');
+  if (leftBracketPos === -1) { return [null, null]; }
+  let rule = string.substring(0, leftBracketPos).trim();
+  if (rule[0] === '=') {
+    rule = rule.substring(1);
+    if (!Number.isNaN(parseInt(rule, 10)) && parseInt(rule, 10) === parseFloat(rule)) {
+      rule = parseInt(rule, 10);
+      rule = PLURAL_RULES[rule];
+      if (rule === undefined) { return [null, null]; }
+    } else { return [null, null]; }
+  } else if (PLURAL_RULES.indexOf(rule) === -1) {
+    return [null, null];
+  }
+  return [rule, string.substring(leftBracketPos)];
+}
+
+function _consumePlural(string) {
+  // {cnt, plural, one {foo} other {foos}}
+  //                   ^^^^^
+  let [bracketCount, escaping] = [0, false];
+  let ptr = 0;
+  while (ptr < string.length) {
+    const char = string[ptr];
+    if (char === "'") {
+      const peek = string[ptr + 1];
+      if (peek === "'") {
+        ptr += 1;
+      } else if (escaping) {
+        escaping = false;
+      } else if (peek === '{' || peek === '}') {
+        escaping = true;
+      }
+    } else if (char === '{') {
+      if (!escaping) {
+        bracketCount += 1;
+      }
+    } else if (char === '}') {
+      if (!escaping) {
+        bracketCount -= 1;
+      }
+      if (bracketCount === 0) {
+        return [string.substring(1, ptr), string.substring(ptr + 1).trim()];
+      }
+    }
+    ptr += 1;
+  }
+  return [null, null];
+}
+
+/**
+ * Determine if a string is an ICU pluralized string. Only works for the
+ * simplest possible case, where the string starts and ends in '{' and '}'
+ * respectively and the root ICU directive is a plural statement. ie This
+ *
+ *   {cnt, plural, one {ONE} other {OTHER}}
+ *
+ * will return 'true' while this
+ *
+ *   hello {cnt, plural, one {ONE} other {OTHER}}
+ *
+ * will return 'false'.
+ *
+ * @param {String} string
+ * @returns {Boolean}
+ */
+export function isPluralized(string) {
+  const [varName, rest] = _consumePreamble(string);
+  let remaining = rest;
+  if (varName == null) { return false; }
+
+  const plurals = {};
+  let rule;
+  let plural;
+  [rule, remaining] = _consumeRule(remaining);
+  if (rule == null) { return false; }
+
+  [plural, remaining] = _consumePlural(remaining.trim());
+  if (plural == null) { return false; }
+  plurals[rule] = plural;
+
+  while (remaining.trim()) {
+    // {cnt, plural, one {foo} other {foos}}
+    //                         ^^^^^^^^^^^^
+    [rule, remaining] = _consumeRule(remaining.trim());
+    if (rule == null) { return false; }
+    [plural, remaining] = _consumePlural(remaining.trim());
+    if (plural == null) { return false; }
+    plurals[rule] = plural;
+  }
+
+  if ((Object.keys(plurals).length === 1 && !('other' in plurals))
+    || (!('one' in plurals && 'other' in plurals))
+  ) {
+    return false;
+  }
+
+  return true;
+}

--- a/packages/native/tests/utils.test.js
+++ b/packages/native/tests/utils.test.js
@@ -2,7 +2,7 @@
 
 import { expect } from 'chai';
 import {
-  escape, generateKey, isString, normalizeLocale,
+  escape, generateKey, isString, normalizeLocale, isPluralized,
 } from '../src/index';
 
 describe('Util functions', () => {
@@ -43,5 +43,13 @@ describe('Util functions', () => {
   it('normalizeLocale', () => {
     expect(normalizeLocale('en')).to.equal('en');
     expect(normalizeLocale('pt-br')).to.equal('pt_BR');
+  });
+
+  it('isPluralized', () => {
+    expect(isPluralized('hello world')).to.equal(false);
+    expect(isPluralized('{cnt, plural, one {ONE} other {OTHER}}'))
+      .to.equal(true);
+    expect(isPluralized('hello {cnt, plural, one {ONE} other {OTHER}}'))
+      .to.equal(false);
   });
 });


### PR DESCRIPTION
During pushing, when we capture a simple pluralized ICU string, the CDS
will push it to transifex like a pluralized string:

    js app -> cds: {cnt, plural, one {ONE} other {OTHER}}

    cds -> APIv3:  {..., strings: {one: "ONE", other: "OTHER"}, ...}

During pulling, the CDS will format the pluralized string back to an ICU
pluralized string. Unfortunately, the variable name has been lost by
this point, so CDS will replace it with '???'

    cds -> js app's cache: {???, plural, one {ΕΝΑ} other {ΑΛΛΟ}}

When rendering a translation, we expect the source string's key to match
the one in the cache and we can extract the variable name to the source
string. So before we feed the translation to the MessageFormat library,
we replace '???' with the variable name:

```javascript
t('{cnt, plural, one {ONE} other {OTHER}}', { cnt: 8 })

key = generateKey(sourceString)
translation = cache.get(key)  // {???, plural, one {ΕΝΑ} other {ΑΛΛΟ}}
if (isPluralized(translation)) {
  translation = `{${varName}${translation.substring(4)}`
  // {cnt, plural, one {ΕΝΑ} other {ΑΛΛΟ}}
}
msg = MF.compile(translation)
return msg(params)
```