### PR TITLE
Bare-minimum typescript declarations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ test_dist
 .nyc_output
 .idea
 npm-debug.log*
+tags

--- a/packages/native/src/index.d.ts
+++ b/packages/native/src/index.d.ts
@@ -1,0 +1,3 @@
+import Native = require('@transifex/native');
+export const tx : Native.tx;
+export const t : Native.t;

--- a/packages/react/src/index.d.ts
+++ b/packages/react/src/index.d.ts
@@ -1,0 +1,7 @@
+import TransifexReact = require('@transifex/react');
+export const T : TransifexReact.T;
+export const LanguagePicker : TransifexReact.LanguagePicker;
+export const T : TransifexReact.T;
+export const UT : TransifexReact.UT;
+export const useLanguages : TransifexReact.useLanguages;
+export const useT : TransifexReact.useT;


### PR DESCRIPTION
Bare-minimum declaration files for `@transifex/native` and `@transifex/react`. This is so that typescript projects don't throw errors.

To test this:

1. Create a new typescript-react project with `npx create-react-app typescript-demo --template typescript`
2. Add some code to `src/App.tsx` that uses `@transifex/native` and `@transifex/react`
   - If you want, for this purpose you can copy-paste the `App.js` and `index.css` files from [txnative-sandbox/react](/transifex/transifex-native-sandbox/tree/master/reactjs/src)

_Note: In order for this to work, this branch should be merged and released first. This cannot be done for reviewing purposes. Perhaps a `npm link` in the `packages/native` and `packages/react` folders will do the trick. Otherwise, you could copy the entire `packages/native/src` and `packages/react/src` folders inside your typescript application's `src` folder. Then, your `App.tsx` should import with `import { tx } from './transifex/native'` and `import { T, ... } from './transifex/react'`. I've done the latter._

Many thanks to Juan Zapata from Phase6 for his help!