### PR TITLE
Interpolation of react elements in T component

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -45,6 +45,39 @@ Available optional props:
 | _charlimit | Number | Character limit instruction for translators |
 | _tags      | String | Comma separated list of tags                |
 
+The T-component can accept React elements as properties and they will be
+rendered properly, ie this would be possible:
+
+```javascript
+<T
+  _str="A {button} and a {bold} walk into a bar"
+  button={<button><T _str="button" /></button>}
+  bold={<b><T _str="bold" /></b>} />
+```
+
+This will render like this in English:
+
+```html
+A <button>button</button> and a <b>bold</b> walk into a bar
+```
+
+And like this in Greek:
+
+```html
+Ένα <button>κουμπί</button> και ένα <b>βαρύ</b> μπαίνουν σε ένα μπαρ
+```
+
+Assuming the translations look like this:
+
+| source                                  | translation                                      |
+|-----------------------------------------|--------------------------------------------------|
+| A {button} and a {bold} walk into a bar | Ένα {button} και ένα {bold} μπαίνουν σε ένα μπαρ |
+| button                                  | κουμπί                                           |
+| bold                                    | βαρύ                                             |
+
+The main thing to keep in mind is that the `_str` property to the T-component
+must **always** be a valid ICU messageformat template.
+
 ### `UT` Component
 
 ```javascript
@@ -72,6 +105,10 @@ Available optional props: All the options of `T` plus:
 | Prop    | Type    | Description                                     |
 |---------|---------|-------------------------------------------------|
 | _inline | Boolean | Wrap translation in `span` when `_html` is used |
+
+_Note: If you supply React elements as properties to the `UT` component, it
+will misbehave by rendering `[object Object]`. Only use React elements as
+properties with the `T` component._
 
 ### `useT` hook
 

--- a/packages/react/src/hooks/useT.js
+++ b/packages/react/src/hooks/useT.js
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
-import {
-  t, onEvent, offEvent, LOCALE_CHANGED,
-} from '@transifex/native';
+import { onEvent, offEvent, LOCALE_CHANGED } from '@transifex/native';
+import translateWithElements from '../utils/translateWithElements';
 
 /* Return a state variable with the translation of `_str` against props. In
  * case the language changes, the variable will be updated, causing the
@@ -19,12 +18,12 @@ import {
  * } */
 
 export default function useT(_str, props) {
-  const [translation, setTranslation] = useState('');
+  const [, setCounter] = useState(0);
   useEffect(() => {
-    function render() { setTranslation(t(_str, props)); }
-    render();
-    onEvent(LOCALE_CHANGED, render);
-    return () => { offEvent(LOCALE_CHANGED, render); };
-  }, [_str, props]);
-  return translation;
+    // Using `setCounter` will trigger a rerender
+    function rerender() { setCounter((c) => c + 1); }
+    onEvent(LOCALE_CHANGED, rerender);
+    return () => { offEvent(LOCALE_CHANGED, rerender); };
+  }, [setCounter]);
+  return translateWithElements(_str, props);
 }

--- a/packages/react/src/utils/translateWithElements.jsx
+++ b/packages/react/src/utils/translateWithElements.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+
+import { t } from '@transifex/native';
+
+/*  Wrapper of `t`-function that can accept React elements as properties. This
+  * works by going through the properties looking for React elements and
+  * replacing them with placeholder text that looks like
+  * "__txnative__X__txnative__" where `X` will help us identify the element in
+  * order to put it back later. The source template and the modified props are
+  * then passed to the regular `t` function. The translation will come back
+  * with the "__txnative__X__txnative__" embedded, as if they were regular
+  * string properties. At this point we replace these with the React elements
+  * that were extracted from the original properties. The final result will be
+  * an array of React elements, each within its unique `key` property and, if
+  * there are more than one, will be returned as `<>{result}</>`. */
+
+function translateWithElements(_str, props) {
+  const actualProps = {};
+  const reactElements = [];
+  Object.entries(props).forEach(([key, value]) => {
+    if (React.isValidElement(value)) {
+      actualProps[key] = `__txnative__${reactElements.length}__txnative__`;
+      reactElements.push(value);
+    } else {
+      actualProps[key] = value;
+    }
+  });
+  const translation = t(_str, actualProps);
+  const result = [];
+  let lastEnd = 0;
+  let lastKey = 0;
+  const regexp = RegExp('__txnative__(\\d+)__txnative__', 'g');
+  let match = regexp.exec(translation);
+  while (match !== null) {
+    const chunk = translation.slice(lastEnd, match.index);
+    if (chunk) {
+      result.push(<React.Fragment key={lastKey}>{chunk}</React.Fragment>);
+      lastKey += 1;
+    }
+    result.push(
+      React.cloneElement(
+        reactElements[parseInt(match[1], 10)], { key: lastKey },
+      ),
+    );
+    lastKey += 1;
+    lastEnd = match.index + match[0].length;
+    match = regexp.exec(translation);
+  }
+  const chunk = translation.slice(lastEnd);
+  if (chunk) {
+    result.push(<React.Fragment key={lastKey}>{chunk}</React.Fragment>);
+  }
+
+  if (result.length === 0) { return ''; }
+  if (result.length === 1) { return result[0].props.children; }
+  return <>{result}</>;
+}
+
+export default translateWithElements;

--- a/packages/react/tests/T.test.jsx
+++ b/packages/react/tests/T.test.jsx
@@ -39,4 +39,9 @@ describe('T', () => {
     );
     expect(screen.getByText('hello world')).toBeTruthy();
   });
+
+  it('renders react elements', () => {
+    render(<T _str="hello {w}" w={<b>world</b>} />);
+    expect(screen.getByText('world')).toBeTruthy();
+  });
 });


### PR DESCRIPTION
Code like this will be possible:

```javascript
<T
  _str="A {button} and a {bold} walk into a bar"
  button={<button><T _str="button" /></button>}
  bold={<b><T _str="bold" /></b>} />
```

This will render like this in English:

```html
A <button>button</button> and a <b>bold</b> walk into a bar
```

And like this in Greek:

```html
Ένα <button>κουμπί</button> και ένα <b>βαρύ</b> μπαίνουν σε ένα μπαρ
```

Assuming the translations look like this:

| source                                  | translation                                      |
|-----------------------------------------|--------------------------------------------------|
| A {button} and a {bold} walk into a bar | Ένα {button} και ένα {bold} μπαίνουν σε ένα μπαρ |
| button                                  | κουμπί                                           |
| bold                                    | βαρύ                                             |

The main thing to keep in mind is that the `_str` property to the
T-component must **always** be a valid ICU messageformat template.