### PR TITLE
Make `t` always return a String

### DIFF
--- a/packages/native/src/TxNative.js
+++ b/packages/native/src/TxNative.js
@@ -124,9 +124,11 @@ export default class TxNative {
         translation = this.missingPolicy.handle(translation, this.currentLocale);
       }
 
+      if (!isString(translation)) translation = `${translation}`;
       return translation;
     } catch (err) {
-      return this.errorPolicy.handle(err, sourceString, this.currentLocale, params);
+      return this.errorPolicy.handle(err,
+        `${sourceString}`, this.currentLocale, params);
     }
   }
 

--- a/packages/native/tests/t.test.js
+++ b/packages/native/tests/t.test.js
@@ -79,4 +79,12 @@ describe('t function', () => {
     tx.currentLocale = prevLocale;
     tx.cache.translationsByLocale = prevTranslationsByLocale;
   });
+
+  it('always returns a string', () => {
+    expect(t('{number}', {
+      number: 1,
+    })).to.equal('1');
+    expect(t({})).to.equal('[object Object]');
+    expect(t(null)).to.equal('null');
+  });
 });


### PR DESCRIPTION
There is an initial issue in @transifex/react in which if for some reason there was a component that had something different than string for "translation" there would result to an error (caused by the react library):

```
<T _str={somevariable} somevariable={3}>
```

This change will result to `t` function always returning a string regardless of the user's input. This way any other recipient should only handle strings instead of implementing something per case.
