### PR TITLE
Introduce pseudotranslation react policy

### DIFF
--- a/packages/native/src/policies/PseudoTranslationPolicy.js
+++ b/packages/native/src/policies/PseudoTranslationPolicy.js
@@ -63,20 +63,25 @@ const MAP = {
  */
 export default class PseudoTranslationPolicy {
   handle(sourceString, localeCode) {
-    let pseudoString = '';
-    for (let i = 0; i < sourceString.length; ++i) {
-      const c = sourceString.charAt(i);
-      if (MAP[c]) {
-        const cl = c.toLowerCase();
-        if (cl === 'a' || cl === 'e' || cl === 'o' || cl === 'u') {
-          pseudoString += MAP[c] + MAP[c];
-        } else {
-          pseudoString += MAP[c];
+    return sourceString
+      .split(/__txnative__/)
+      .map((group) => {
+        let pseudoString = '';
+        for (let i = 0; i < group.length; i += 1) {
+          const c = group.charAt(i);
+          if (MAP[c]) {
+            const cl = c.toLowerCase();
+            if (cl === 'a' || cl === 'e' || cl === 'o' || cl === 'u') {
+              pseudoString += MAP[c] + MAP[c];
+            } else {
+              pseudoString += MAP[c];
+            }
+          } else {
+            pseudoString += c;
+          }
         }
-      } else {
-        pseudoString += c;
-      }
-    }
-    return pseudoString;
+        return pseudoString;
+      })
+      .join('__txnative__');
   }
 }

--- a/packages/native/tests/policies.test.js
+++ b/packages/native/tests/policies.test.js
@@ -14,9 +14,16 @@ describe('Missing policy', () => {
     expect(policy.handle('Hello {}')).to.equal('Hello {}');
   });
 
-  it('PseudoTranslationPolicy works', () => {
-    const policy = new PseudoTranslationPolicy();
-    expect(policy.handle('Hello {}')).to.equal('Ħḗḗŀŀǿǿ {}');
+  describe('PseudoTranslationPolicy', () => {
+    it('works', () => {
+      const policy = new PseudoTranslationPolicy();
+      expect(policy.handle('Hello {}')).to.equal('Ħḗḗŀŀǿǿ {}');
+    });
+
+    it('ignores react interpolation properties', () => {
+      const policy = new PseudoTranslationPolicy();
+      expect(policy.handle('Hello __txnative__50__txnative__ world')).to.equal('Ħḗḗŀŀǿǿ __txnative__50__txnative__ ẇǿǿřŀḓ');
+    });
   });
 });
 


### PR DESCRIPTION
# Description

Currently the pseudotranslation policy in the native package will
convert all characters it finds. This means that the __txnative__ words
used to handle react interpolation are also converted, which completely
removes the interpolation functionality.

This commit introduces a new policy specifically in the react package
which allows this functionality to continue to work, by purposely not
coverting any instance of "__txnative__".

This was introduced in the react package because the native package
should have no concept of the react package, and so the only reasonable
way to handle this is to introduce a react-specific policy to handle
this.

## Questions
- I understand that I'm introducing a new concept of policies in the react package. Happy to discuss whether this is the right approach, but it seemed the most reasonable to keep independence of the native package while resolving the problem.
- Please let me know if there's a preferred PR format for contributions
- I'm unable to sign the CLA as it is hidden in a login-protected Transifex Docs page. If this is made available I'll happily sign the CLA