### PR TITLE
Remove package-lock.json when releasing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: node_js
 node_js:
   - 10
-  - 11
   - 12
-  - 13
   - 14
 
 cache:

--- a/package.json
+++ b/package.json
@@ -6,10 +6,11 @@
     "bootstrap": "lerna bootstrap --no-ci",
     "test": "lerna run test",
     "build": "lerna run build",
-    "release": "lerna version",
+    "release": "del-cli packages/**/package-lock.json && lerna version",
     "publish": "lerna exec -- npm publish"
   },
   "devDependencies": {
+    "del-cli": "^3.0.1",
     "lerna": "^3.22.1"
   }
 }


### PR DESCRIPTION
`package-lock.json` is on `.gitignore` file, however when releasing a new version using `lerna`, it complains about lock files that are created during local development. So in order to release, you need to manually remove `package-lock.json` from the libraries and retry.

This PR is putting the deletion of lock files as part of the `npm run release` command.