### PR TITLE
Transpile functionality to support non-Chrome Edge

### DIFF
--- a/packages/react/.babelrc
+++ b/packages/react/.babelrc
@@ -9,5 +9,6 @@
       }
     ],
     "@babel/preset-react"
-  ]
+  ],
+  "plugins": [["@babel/plugin-proposal-object-rest-spread", { "loose": true, "useBuiltIns": true }]]
 }


### PR DESCRIPTION
The function({...x}) functionality (see
https://github.com/tc39/proposal-object-rest-spread) is not supported in
non-Chromium Edge. While this browser will be heading away soon-ish, I
think it's still important to ensure this is supported until then. This
is a very simple change to ensure that the code transpiles to allow this
functionality for the browser.