### PR TITLE
CLI: Filter content by tags, add invalidate command

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -52,6 +52,7 @@ $ npm run push
 # Commands
 * [`txjs-cli help [COMMAND]`](#txjs-cli-help-command)
 * [`txjs-cli push [PATTERN]`](#txjs-cli-push-pattern)
+* [`txjs-cli invalidate`](#txjs-cli-invalidate)
 
 ## `txjs-cli help [COMMAND]`
 
@@ -70,7 +71,7 @@ OPTIONS
 
 ## `txjs-cli push [PATTERN]`
 
-Detect translatable strings and push content to Transifex
+detect and push source content to Transifex
 
 ```
 USAGE
@@ -80,13 +81,13 @@ ARGUMENTS
   PATTERN  [default: **/*.{js,jsx,ts,tsx}] file pattern to scan for strings
 
 OPTIONS
-  -v, --verbose        Verbose output
+  -v, --verbose        verbose output
   --cds-host=cds-host  CDS host URL
-  --dry-run            Dry run, do not push to Transifex
-  --purge              Purge content on Transifex
-  --secret=secret      Native project secret
-  --token=token        Native project public token
-  --tags=tags          Globally add tags to strings
+  --dry-run            dry run, do not push to Transifex
+  --purge              purge content on Transifex
+  --secret=secret      native project secret
+  --tags=tags          globally tag strings
+  --token=token        native project public token
 
 DESCRIPTION
   Parse .js, .ts, .jsx and .tsx files and detect phrases marked for
@@ -111,6 +112,47 @@ DESCRIPTION
   txjs-cli push --tags="master,release:2.5"
   txjs-cli push --token=mytoken --secret=mysecret
   TRANSIFEX_TOKEN=mytoken TRANSIFEX_SECRET=mysecret txjs-cli push
+```
+
+## `txjs-cli invalidate`
+
+invalidate and refresh CDS cache
+
+```
+USAGE
+  $ txjs-cli invalidate
+
+OPTIONS
+  --cds-host=cds-host  CDS host URL
+  --purge              force delete CDS cached content
+  --secret=secret      native project secret
+  --token=token        native project public token
+
+DESCRIPTION
+  Content for delivery is cached in CDS and refreshed automatically every hour.
+  This command triggers a refresh of cached content on the fly.
+
+  By default, invalidation does not remove existing cached content, but
+  starts the process of updating with latest translations from Transifex.
+
+  Passing the --purge option, cached content will be forced to be deleted,
+  however use that with caution, as it may introduce downtime of
+  translation delivery to the apps until fresh content is cached in the CDS.
+
+  To invalidate translations some environment variables must be set:
+  TRANSIFEX_TOKEN=<Transifex Native Project Token>
+  TRANSIFEX_SECRET=<Transifex Native Project Secret>
+  (optional) TRANSIFEX_CDS_HOST=<CDS HOST>
+
+  or passed as --token=<TOKEN> --secret=<SECRET> parameters
+
+  Default CDS Host is https://cds.svc.transifex.net
+
+  Examples:
+  txjs-cli invalidate
+  txjs-cli invalidate --purge
+  txjs-cli invalidate --token=mytoken --secret=mysecret
+  TRANSIFEX_TOKEN=mytoken TRANSIFEX_SECRET=mysecret txjs-cli invalidate
 ```
 
 # License

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -81,13 +81,15 @@ ARGUMENTS
   PATTERN  [default: **/*.{js,jsx,ts,tsx}] file pattern to scan for strings
 
 OPTIONS
-  -v, --verbose        verbose output
-  --cds-host=cds-host  CDS host URL
-  --dry-run            dry run, do not push to Transifex
-  --purge              purge content on Transifex
-  --secret=secret      native project secret
-  --tags=tags          globally tag strings
-  --token=token        native project public token
+  -v, --verbose                          verbose output
+  --append-tags=append-tags              append tags to strings
+  --cds-host=cds-host                    CDS host URL
+  --dry-run                              dry run, do not push to Transifex
+  --purge                                purge content on Transifex
+  --secret=secret                        native project secret
+  --token=token                          native project public token
+  --with-tags-only=with-tags-only        push strings with specific tags
+  --without-tags-only=without-tags-only  push strings without specific tags
 
 DESCRIPTION
   Parse .js, .ts, .jsx and .tsx files and detect phrases marked for
@@ -109,7 +111,9 @@ DESCRIPTION
   txjs-cli push /home/repo/src
   txjs-cli push "*.js"
   txjs-cli push --dry-run
-  txjs-cli push --tags="master,release:2.5"
+  txjs-cli push --append-tags="master,release:2.5"
+  txjs-cli push --with-tags-only="home,error"
+  txjs-cli push --without-tags-only="custom"
   txjs-cli push --token=mytoken --secret=mysecret
   TRANSIFEX_TOKEN=mytoken TRANSIFEX_SECRET=mysecret txjs-cli push
 ```

--- a/packages/cli/src/api/invalidate.js
+++ b/packages/cli/src/api/invalidate.js
@@ -1,0 +1,47 @@
+const axios = require('axios');
+const { version } = require('../../package.json');
+
+/**
+ * Invalidate CDS cache
+ *
+ * @param {Object} params
+ * @param {String} params.url
+ * @param {String} params.token
+ * @param {String} params.secret
+ * @param {Boolean} params.purge
+ * @returns {Object} Data
+ * @returns {Boolean} Data.success
+ * @returns {String} Data.status
+ * @returns {Number} Data.data.count
+ * @returns {Number} Data.data.status
+ * @returns {Number} Data.data.token
+ */
+async function invalidateCDS(params) {
+  const action = params.purge ? 'purge' : 'invalidate';
+  try {
+    const res = await axios.post(`${params.url}/${action}`, {
+    }, {
+      headers: {
+        Authorization: `Bearer ${params.token}:${params.secret}`,
+        'Content-Type': 'application/json;charset=utf-8',
+        'X-NATIVE-SDK': `txjs/cli/${version}`,
+      },
+    });
+    return {
+      success: true,
+      status: res.status,
+      data: res.data,
+    };
+  } catch (error) {
+    if (error.response) {
+      return {
+        success: false,
+        status: error.response.status,
+        data: error.response.data,
+      };
+    }
+    throw new Error(error.message);
+  }
+}
+
+module.exports = invalidateCDS;

--- a/packages/cli/src/commands/invalidate.js
+++ b/packages/cli/src/commands/invalidate.js
@@ -1,0 +1,103 @@
+/* eslint no-shadow: 0 */
+
+require('colors');
+const { Command, flags } = require('@oclif/command');
+const { cli } = require('cli-ux');
+const invalidateCDS = require('../api/invalidate');
+
+class InvalidateCommand extends Command {
+  async run() {
+    const { flags } = this.parse(InvalidateCommand);
+
+    let cdsHost = process.env.TRANSIFEX_CDS_HOST || 'https://cds.svc.transifex.net';
+    let projectToken = process.env.TRANSIFEX_TOKEN;
+    let projectSecret = process.env.TRANSIFEX_SECRET;
+
+    if (flags.token) projectToken = flags.token;
+    if (flags.secret) projectSecret = flags.secret;
+    if (flags['cds-host']) cdsHost = flags['cds-host'];
+
+    if (!projectToken || !projectSecret) {
+      this.log(`${'✘'.red} Cannot invalidate CDS, credentials are missing.`);
+      this.log('Tip: Set TRANSIFEX_TOKEN and TRANSIFEX_SECRET environment variables'.yellow);
+      process.exit();
+    }
+
+    if (flags.purge) {
+      cli.action.start('Invalidating and purging CDS cache', '', { stdout: true });
+    } else {
+      cli.action.start('Invalidating CDS cache', '', { stdout: true });
+    }
+
+    try {
+      const res = await invalidateCDS({
+        url: cdsHost,
+        token: projectToken,
+        secret: projectSecret,
+        purge: flags.purge,
+      });
+      if (res.success) {
+        cli.action.stop('Success'.green);
+        this.log(`${(res.data.count || 0).toString().green} records invalidated`);
+        this.log('Note: It might take a few minutes for fresh content to be available'.yellow);
+      } else {
+        cli.action.stop('Failed'.red);
+        this.log(`Status code: ${res.status}`.red);
+        this.error(JSON.stringify(res.data));
+      }
+    } catch (err) {
+      cli.action.stop('Failed'.red);
+      throw err;
+    }
+  }
+}
+
+InvalidateCommand.description = `invalidate and refresh CDS cache
+Content for delivery is cached in CDS and refreshed automatically every hour.
+This command triggers a refresh of cached content on the fly.
+
+By default, invalidation does not remove existing cached content, but
+starts the process of updating with latest translations from Transifex.
+
+Passing the --purge option, cached content will be forced to be deleted,
+however use that with caution, as it may introduce downtime of
+translation delivery to the apps until fresh content is cached in the CDS.
+
+To invalidate translations some environment variables must be set:
+TRANSIFEX_TOKEN=<Transifex Native Project Token>
+TRANSIFEX_SECRET=<Transifex Native Project Secret>
+(optional) TRANSIFEX_CDS_HOST=<CDS HOST>
+
+or passed as --token=<TOKEN> --secret=<SECRET> parameters
+
+Default CDS Host is https://cds.svc.transifex.net
+
+Examples:
+txjs-cli invalidate
+txjs-cli invalidate --purge
+txjs-cli invalidate --token=mytoken --secret=mysecret
+TRANSIFEX_TOKEN=mytoken TRANSIFEX_SECRET=mysecret txjs-cli invalidate
+`;
+
+InvalidateCommand.args = [];
+
+InvalidateCommand.flags = {
+  purge: flags.boolean({
+    description: 'force delete CDS cached content',
+    default: false,
+  }),
+  token: flags.string({
+    description: 'native project public token',
+    default: '',
+  }),
+  secret: flags.string({
+    description: 'native project secret',
+    default: '',
+  }),
+  'cds-host': flags.string({
+    description: 'CDS host URL',
+    default: '',
+  }),
+};
+
+module.exports = InvalidateCommand;

--- a/packages/cli/src/commands/push.js
+++ b/packages/cli/src/commands/push.js
@@ -170,7 +170,7 @@ class PushCommand extends Command {
   }
 }
 
-PushCommand.description = `Detect translatable strings and push content to Transifex
+PushCommand.description = `detect and push source content to Transifex
 Parse .js, .ts, .jsx and .tsx files and detect phrases marked for
 translation by Transifex Native toolkit for Javascript and
 upload them to Transifex for translation.
@@ -204,28 +204,28 @@ PushCommand.args = [{
 
 PushCommand.flags = {
   'dry-run': flags.boolean({
-    description: 'Dry run, do not push to Transifex',
+    description: 'dry run, do not push to Transifex',
     default: false,
   }),
   verbose: flags.boolean({
     char: 'v',
-    description: 'Verbose output',
+    description: 'verbose output',
     default: false,
   }),
   purge: flags.boolean({
-    description: 'Purge content on Transifex',
+    description: 'purge content on Transifex',
     default: false,
   }),
   token: flags.string({
-    description: 'Native project public token',
+    description: 'native project public token',
     default: '',
   }),
   secret: flags.string({
-    description: 'Native project secret',
+    description: 'native project secret',
     default: '',
   }),
   tags: flags.string({
-    description: 'Globally tag strings',
+    description: 'globally tag strings',
     default: '',
   }),
   'cds-host': flags.string({

--- a/packages/cli/test/api/extract.test.js
+++ b/packages/cli/test/api/extract.test.js
@@ -32,8 +32,8 @@ describe('extractPhrases', () => {
       });
   });
 
-  it('works with global tags', async () => {
-    expect(await extractPhrases('test/fixtures/webpack.js', 'webpack.js', ['g1', 'g2']))
+  it('works with append tags', async () => {
+    expect(await extractPhrases('test/fixtures/webpack.js', 'webpack.js', { appendTags: ['g1', 'g2'] }))
       .to.deep.equal({
         '6f48100ca5a57d2db9b685a8373be8a6': {
           string: 'Text 1',

--- a/packages/cli/test/commands/invalidate.test.js
+++ b/packages/cli/test/commands/invalidate.test.js
@@ -1,0 +1,44 @@
+/* globals describe */
+const { expect, test } = require('@oclif/test');
+
+describe('invalidate command', () => {
+  test
+    .nock('https://cds.svc.transifex.net', (api) => api
+      .post('/invalidate')
+      .reply(200, {
+        status: 'success',
+        token: 't',
+        count: 5,
+      }))
+    .stdout()
+    .command(['invalidate', '--secret=s', '--token=t'])
+    .it('invalidates content', (ctx) => {
+      expect(ctx.stdout).to.contain('5 records invalidated');
+    });
+
+  test
+    .nock('https://cds.svc.transifex.net', (api) => api
+      .post('/purge')
+      .reply(200, {
+        status: 'success',
+        token: 't',
+        count: 10,
+      }))
+    .stdout()
+    .command(['invalidate', '--purge', '--secret=s', '--token=t'])
+    .it('invalidates content', (ctx) => {
+      expect(ctx.stdout).to.contain('10 records invalidated');
+    });
+
+  test
+    .nock('https://cds.svc.transifex.net', (api) => api
+      .post('/invalidate')
+      .reply(403))
+    .stdout()
+    .stderr()
+    .command(['invalidate', '--secret=s', '--token=t'])
+    .exit(2)
+    .it('handles invalidate error', (ctx) => {
+      expect(ctx.stdout).to.contain('Status code: 403');
+    });
+});

--- a/packages/cli/test/commands/push.test.js
+++ b/packages/cli/test/commands/push.test.js
@@ -43,6 +43,32 @@ describe('push command', () => {
     });
 
   test
+    .stdout()
+    .command(['push', 'test/fixtures/tags.js', '--dry-run', '-v', '--append-tags=custom'])
+    .it('append tags', (ctx) => {
+      expect(ctx.stdout).to.contain('tags: ["tag1","tag2","custom"]');
+      expect(ctx.stdout).to.contain('tags: ["tag2","tag3","custom"]');
+      expect(ctx.stdout).to.contain('tags: ["custom"]');
+    });
+
+  test
+    .stdout()
+    .command(['push', 'test/fixtures/tags.js', '--dry-run', '-v', '--with-tags-only=tag1'])
+    .it('filters-in tags', (ctx) => {
+      expect(ctx.stdout).to.not.contain('tag3');
+      expect(ctx.stdout).to.contain('tag1');
+    });
+
+  test
+    .stdout()
+    .command(['push', 'test/fixtures/tags.js', '--dry-run', '-v', '--without-tags-only=tag1'])
+    .it('filters-out tags', (ctx) => {
+      expect(ctx.stdout).to.contain('tag2');
+      expect(ctx.stdout).to.contain('tag3');
+      expect(ctx.stdout).to.not.contain('tag1');
+    });
+
+  test
     .nock('https://cds.svc.transifex.net', (api) => api
       .post('/content')
       .reply(200, {

--- a/packages/cli/test/fixtures/tags.js
+++ b/packages/cli/test/fixtures/tags.js
@@ -1,0 +1,5 @@
+import { t } from '@transifex/native';
+
+t('Text 1', { _tags: 'tag1,tag2' });
+t('Text 2', { _tags: 'tag2,tag3' });
+t('Text 3');


### PR DESCRIPTION
Update CLI with the following changes:
- Rename `--tags` option to `--append-tags` to make it more descriptive what this flag does (breaking change)
- Add `--with-tags-only` flag to filter in for push only strings with specific tags
- Add `--without-tags-only` flag to filter out for push only strings without specific tags
- Add `txjs-cli invalidate` command as a helper to invalidate CDS cache