### PR TITLE
Remove source lang from React LanguagePicker

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -175,7 +175,6 @@ function App () {
 
 Accepts properties:
 
-- `sourceLanguage`: defaults to `{code: 'en', name: 'English'}`
 - `className`: The CSS class that will be applied to the `<select>` tag
 
 If you want something different than a `<select>`, it should be easy to write
@@ -191,9 +190,6 @@ function MyLanguagePicker () {
 
   return (
     <>
-      <button onClick={() => tx.setCurrentLocale('en')}>
-        English
-      </button>
       {languages.map(({ code, name }) => (
         <button key={code} onClick={() => tx.setCurrentLocale(code)}>
           {name}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -34,7 +34,7 @@
     "node": ">=10.0.0"
   },
   "peerDependencies": {
-    "@transifex/native": "^0.7.0 || ^0.8.0 || ^0.9.0",
+    "@transifex/native": "^0.9.0",
     "prop-types": "^15.0.0",
     "react": "^16.0.0 || ^17.0.0"
   },

--- a/packages/react/src/components/LanguagePicker.jsx
+++ b/packages/react/src/components/LanguagePicker.jsx
@@ -8,12 +8,9 @@ import useLanguages from '../hooks/useLanguages';
 /* Component to render a language picker. Language options will be fetched
   * asynchronously. Accepts props:
   *
-  * - sourceLanguage: an object with 'code' and 'name' fields, defaults to
-  *   `{code: 'en', name: 'English'}`
-  *
   * - className: the CSS class to use on the <select> tag */
 
-export default function LanguagePicker({ sourceLanguage, className }) {
+export default function LanguagePicker({ className }) {
   const languages = useLanguages();
 
   return (
@@ -21,7 +18,6 @@ export default function LanguagePicker({ sourceLanguage, className }) {
       className={className}
       onChange={(e) => tx.setCurrentLocale(e.target.value)}
     >
-      <option value={sourceLanguage.code}>{sourceLanguage.name}</option>
       {languages.map(({ name, code }) => (
         <option key={code} value={code}>{name}</option>
       ))}
@@ -30,14 +26,9 @@ export default function LanguagePicker({ sourceLanguage, className }) {
 }
 
 LanguagePicker.propTypes = {
-  sourceLanguage: (
-    PropTypes
-      .shape({ name: PropTypes.string, code: PropTypes.string })
-  ),
   className: PropTypes.string,
 };
 
 LanguagePicker.defaultProps = {
-  sourceLanguage: { code: 'en', name: 'English' },
   className: '',
 };

--- a/packages/react/src/hooks/useLanguages.js
+++ b/packages/react/src/hooks/useLanguages.js
@@ -11,7 +11,6 @@ import { tx } from '@transifex/native';
  *
  *   return (
  *     <select onChange={ (e) => tx.setCurrentLocale(e.target.value) }>
- *       <option value='en'>English</option>
  *       { languages.map(({code, name}) => (
  *         <option key={ code } value={ code }>{ name }</option>
  *       )) }

--- a/packages/react/tests/LanguagePicker.test.jsx
+++ b/packages/react/tests/LanguagePicker.test.jsx
@@ -26,7 +26,6 @@ afterEach(() => {
 test('display language picker', async () => {
   render(<LanguagePicker />);
   await waitFor(() => screen.getByText('Greek'));
-  expect(screen.queryByText('English')).toBeTruthy();
   expect(screen.queryByText('Greek')).toBeTruthy();
   expect(screen.queryByText('French')).toBeTruthy();
 });


### PR DESCRIPTION
There is no need to append the source language manually in the LanguagePicker component after the `0.9.0` version.