### PR TITLE
Fix issue with useT

### DIFF
--- a/packages/react/src/utils/translateWithElements.jsx
+++ b/packages/react/src/utils/translateWithElements.jsx
@@ -17,14 +17,16 @@ import { t } from '@transifex/native';
 function translateWithElements(_str, props) {
   const actualProps = {};
   const reactElements = [];
-  Object.entries(props).forEach(([key, value]) => {
-    if (React.isValidElement(value)) {
-      actualProps[key] = `__txnative__${reactElements.length}__txnative__`;
-      reactElements.push(value);
-    } else {
-      actualProps[key] = value;
-    }
-  });
+  if (props) {
+    Object.entries(props).forEach(([key, value]) => {
+      if (React.isValidElement(value)) {
+        actualProps[key] = `__txnative__${reactElements.length}__txnative__`;
+        reactElements.push(value);
+      } else {
+        actualProps[key] = value;
+      }
+    });
+  }
   const translation = t(_str, actualProps);
   const result = [];
   let lastEnd = 0;

--- a/packages/react/tests/useT.test.jsx
+++ b/packages/react/tests/useT.test.jsx
@@ -1,0 +1,79 @@
+/* globals describe, it, expect, afterEach */
+
+import React, { useState } from 'react';
+
+import {
+  render, screen, cleanup, fireEvent, act,
+} from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { sendEvent, LOCALE_CHANGED } from '@transifex/native';
+import { useT } from '../src';
+
+describe('useT', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders text', () => {
+    function MyComp() {
+      const message = useT('Hello <b>safe text</b>');
+      return (message);
+    }
+
+    render(<MyComp />);
+    expect(screen.queryByText('Hello <b>safe text</b>')).toBeInTheDocument();
+  });
+
+  it('renders text with param', () => {
+    function MyComp() {
+      const message = useT('Hello <b>{username}</b>', {
+        username: 'JohnDoe',
+      });
+      return (message);
+    }
+
+    render(<MyComp />);
+    expect(screen.queryByText('Hello <b>JohnDoe</b>')).toBeInTheDocument();
+  });
+
+  it('rerenders on prop change', () => {
+    const MyComp = () => {
+      const [word, setWord] = useState('');
+      const message = useT('hello {word}', {
+        word,
+      });
+      return (
+        <>
+          <input value={word} onChange={(e) => setWord(e.target.value)} />
+          <p>{message}</p>
+        </>
+      );
+    };
+    render(<MyComp />);
+    fireEvent.change(
+      screen.getByRole('textbox'),
+      { target: { value: 'world' } },
+    );
+    expect(screen.getByText('hello world')).toBeTruthy();
+  });
+
+  it('renders react elements', () => {
+    const MyComp = () => {
+      const [word, setWord] = useState('');
+      const message = useT('hello {w}', {
+        w: <b>world</b>,
+      });
+      return (
+        <>
+          <input value={word} onChange={(e) => setWord(e.target.value)} />
+          <p>{message}</p>
+        </>
+      );
+    };
+    render(<MyComp />);
+    expect(screen.getByText('world')).toBeTruthy();
+    act(() => {
+      sendEvent(LOCALE_CHANGED);
+    });
+  });
+});


### PR DESCRIPTION
Addresses the issue in #48 for useT.
I case no `props` passed to the function it would break. We were missing a check/or a default on the `props` value.
The tests added are identical to the `T` component, since the result of these two should be identical.