### PR TITLE
Support transitional empty strings in expressions, but do not collect them

### DIFF
--- a/packages/cli/src/api/extract.js
+++ b/packages/cli/src/api/extract.js
@@ -159,7 +159,7 @@ function findDeclaredValue(scope, init) {
     const left = findDeclaredValue(scope, init.left);
     const right = findDeclaredValue(scope, init.right);
 
-    if (left && right) {
+    if (_.isString(left) && _.isString(right)) {
       return left + right;
     }
   }
@@ -209,6 +209,8 @@ function extractPhrases(file, relativeFile, options = {}) {
           }
         });
       }
+
+      if (!string) return;
 
       const partial = createPayload(string, params, relativeFile, appendTags);
       if (!isPayloadValid(partial, options)) return;

--- a/packages/cli/test/fixtures/simple.js
+++ b/packages/cli/test/fixtures/simple.js
@@ -14,6 +14,7 @@ t('Text 1' + text);
 Instance.translate(text);
 
 // invalid
+t('');
 Instance.translateme('Text 5');
 Instance.translate();
 Instance.translate({ foo: 'bar' });

--- a/packages/cli/test/fixtures/variables.js
+++ b/packages/cli/test/fixtures/variables.js
@@ -3,8 +3,8 @@ const { t } = require('@transifex/native');
 function log() {}
 
 const outer = 'Outer Text';
-const long = 
-    ' Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text'
+const long = ''
+  + ' Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text'
   + ' Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text'
   + ' Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text';
 const merged = outer + long;


### PR DESCRIPTION
This PR fixes a small issue with parsing string expressions when calling `t()` function.

Currently, empty string (which often is part of a longer string) will be incorrectly recognized as `false` thus causing the whole string to be rejected. This can cause hard to debug problems where `t('' + 'a')` will fail, but `t(' ' + 'a')` will succeed.

On top of that I'm fixing small inconsistency between the translation methods available - namely, `t() / useT()` accepts empty string and extracts it, but `<T> / <UT>` checks if `_str=` parameter is empty and skips the extraction in that case.
This PR will reject empty strings (or binary expressions which resolve to empty strings) when passed to `t()`.
