### PR TITLE
Add types for native exports

### DIFF
--- a/packages/native/src/index.d.ts
+++ b/packages/native/src/index.d.ts
@@ -1,3 +1,7 @@
 import Native = require('@transifex/native');
 export const tx : Native.tx;
 export const t : Native.t;
+export const PseudoTranslationPolicy: Native.PseudoTranslationPolicy;
+export const SourceStringPolicy: Native.SourceStringPolicy;
+export const SourceErrorPolicy: Native.SourceErrorPolicy;
+export const ThrowErrorPolicy: Native.ThrowErrorPolicy;


### PR DESCRIPTION
This PR just adds additional types to the native package. When trying to use `PseudoTranslationPolicy` in my typescript project, I was unable to due to this, so I figured I'd add it here.

Please let me know if there's anything I'm missing in adding these!