### PR TITLE
Introduce abstract StringRenderer class

### DIFF
--- a/packages/angular/projects/tx-native-angular-sdk/README.md
+++ b/packages/angular/projects/tx-native-angular-sdk/README.md
@@ -223,9 +223,10 @@ export interface ITranslationServiceConfig {
   cache?: () => void;
   missingPolicy?: () => void;
   errorPolicy?: () => void;
+  stringRenderer?: () => void;
 }
 ```
-- `cache`, `missingPolicy` and `errorPolicy` are set by default by
+- `cache`, `missingPolicy`, `errorPolicy` and `stringRenderer` are set by default by
 `@transifex/native` package but you can provide if you wish custom functions
 of your own, or use another policy provided by the `@transifex/native` package.
 

--- a/packages/angular/projects/tx-native-angular-sdk/src/lib/interfaces.ts
+++ b/packages/angular/projects/tx-native-angular-sdk/src/lib/interfaces.ts
@@ -6,6 +6,7 @@ export interface ITranslationServiceConfig {
   cache?: () => void;
   missingPolicy?: () => void;
   errorPolicy?: () => void;
+  stringRenderer?: () => void;
 }
 
 export interface ILanguage {

--- a/packages/angular/projects/tx-native-angular-sdk/tests/translation.service.spec.ts
+++ b/packages/angular/projects/tx-native-angular-sdk/tests/translation.service.spec.ts
@@ -13,6 +13,7 @@ describe('TranslationService', () => {
     errorPolicy: () => { },
     filterTags: '',
     missingPolicy: () => { },
+    stringRenderer: () => { },
   };
   const translationParams = {
     _key: '',

--- a/packages/native/README.md
+++ b/packages/native/README.md
@@ -109,6 +109,9 @@ tx.init({
   // Error policy, defaults to "new SourceErrorPolicy()"
   errorPolicy: Function,
 
+  // String renderer, defaults to "new MessageFormatRenderer()"
+  stringRenderer: Function,
+
   // Translation cache, defaults to "new MemoryCache()"
   cache: Function,
 })

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -31,28 +31,28 @@
     "node": ">=10.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.13.10",
-    "@babel/plugin-transform-runtime": "^7.13.10",
-    "@babel/preset-env": "^7.13.10",
-    "@babel/runtime": "^7.13.10",
+    "@babel/core": "^7.14.5",
+    "@babel/plugin-transform-runtime": "^7.14.5",
+    "@babel/preset-env": "^7.14.5",
+    "@babel/runtime": "^7.14.5",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.1.0",
-    "chai": "^4.3.3",
-    "eslint": "^7.21.0",
+    "chai": "^4.3.4",
+    "eslint": "^7.28.0",
     "eslint-config-airbnb-base": "^14.2.0",
     "eslint-loader": "^4.0.2",
-    "eslint-plugin-import": "^2.22.1",
-    "glob": "^7.1.6",
-    "mocha": "^8.3.1",
-    "nock": "^13.0.11",
+    "eslint-plugin-import": "^2.23.4",
+    "glob": "^7.1.7",
+    "mocha": "^8.4.0",
+    "nock": "^13.1.0",
     "nyc": "^15.1.0",
     "source-map-support": "^0.5.19",
     "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12"
   },
   "dependencies": {
+    "@messageformat/core": "^3.0.0",
     "axios": "^0.21.1",
-    "md5": "^2.3.0",
-    "messageformat": "^2.3.0"
+    "md5": "^2.3.0"
   }
 }

--- a/packages/native/src/index.d.ts
+++ b/packages/native/src/index.d.ts
@@ -5,3 +5,4 @@ export const PseudoTranslationPolicy: Native.PseudoTranslationPolicy;
 export const SourceStringPolicy: Native.SourceStringPolicy;
 export const SourceErrorPolicy: Native.SourceErrorPolicy;
 export const ThrowErrorPolicy: Native.ThrowErrorPolicy;
+export const MessageFormatRenderer: Native.MessageFormatRenderer;

--- a/packages/native/src/index.js
+++ b/packages/native/src/index.js
@@ -5,6 +5,7 @@ import _SourceStringPolicy from './policies/SourceStringPolicy';
 
 import _SourceErrorPolicy from './policies/SourceErrorPolicy';
 import _ThrowErrorPolicy from './policies/ThrowErrorPolicy';
+import _MessageFormatRenderer from './renderers/MessageFormatRenderer';
 
 export * from './utils';
 export * from './events';
@@ -13,6 +14,7 @@ export const PseudoTranslationPolicy = _PseudoTranslationPolicy;
 export const SourceStringPolicy = _SourceStringPolicy;
 export const SourceErrorPolicy = _SourceErrorPolicy;
 export const ThrowErrorPolicy = _ThrowErrorPolicy;
+export const MessageFormatRenderer = _MessageFormatRenderer;
 
 export const tx = new TxNative();
 export const t = tx.translate.bind(tx);

--- a/packages/native/src/renderers/MessageFormatRenderer.js
+++ b/packages/native/src/renderers/MessageFormatRenderer.js
@@ -1,0 +1,17 @@
+/* eslint-disable class-methods-use-this */
+import MessageFormat from '@messageformat/core';
+
+const MF = new MessageFormat();
+
+/**
+ * MessageFormat renderer
+ *
+ * @export
+ * @class MessageFormatRenderer
+ */
+export default class MessageFormatRenderer {
+  render(sourceString, localeCode, params) {
+    const msg = MF.compile(sourceString);
+    return msg(params);
+  }
+}

--- a/packages/native/tests/renderer.test.js
+++ b/packages/native/tests/renderer.test.js
@@ -1,0 +1,28 @@
+/* globals describe, it */
+
+import { expect } from 'chai';
+import { tx, t } from '../src/index';
+
+describe('String renderer', () => {
+  it('renders with custom renderer', async () => {
+    const oldRenderer = tx.stringRenderer;
+
+    class CustomRenderer {
+      // eslint-disable-next-line class-methods-use-this
+      render() {
+        return 'foo';
+      }
+    }
+
+    tx.init({
+      stringRenderer: new CustomRenderer(),
+    });
+
+    expect(t('Hello')).to.deep.equal('foo');
+
+    // revert
+    tx.init({
+      stringRenderer: oldRenderer,
+    });
+  });
+});

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -35,7 +35,7 @@
     "node": ">=10.0.0"
   },
   "peerDependencies": {
-    "@transifex/native": "^0.11.0 || ^0.12.0",
+    "@transifex/native": "^0.12.0 || ^0.13.0",
     "prop-types": "^15.0.0",
     "react": "^16.0.0 || ^17.0.0"
   },


### PR DESCRIPTION
Decouple MessageFormat library from Native, add an interface to override default renderer and create custom implementations for advanced use cases.

Related to #60 