### PR TITLE
CLI: Detect _str const literals on T components

### DIFF
--- a/packages/cli/test/api/extract.test.js
+++ b/packages/cli/test/api/extract.test.js
@@ -95,6 +95,14 @@ describe('extractPhrases', () => {
           string: 'uses useT',
           meta: { context: [], tags: [], occurrences: ['react.jsx'] },
         },
+        '41ea834f9604545bba088de53e71a159': {
+          string: 'uses useT as const',
+          meta: { context: [], tags: [], occurrences: ['react.jsx'] },
+        },
+        '14a6af017c176654aaf0df13d1179418': {
+          string: 'uses _str as const',
+          meta: { context: [], tags: [], occurrences: ['react.jsx'] },
+        },
         '6f48100ca5a57d2db9b685a8373be8a6': {
           string: 'Text 1',
           meta: {

--- a/packages/cli/test/fixtures/react.jsx
+++ b/packages/cli/test/fixtures/react.jsx
@@ -2,6 +2,11 @@ import { T, UT, useT } from '@transifex/react';
 
 function foo() {
   let msg = useT('uses useT');
+
+  const str2 = 'uses useT as const';
+  let msg2 = useT(str2);
+
+  const str3 = 'uses _str as const';
   return (
     <div>
       <T
@@ -19,7 +24,9 @@ function foo() {
           bold={<b><T _str="bold" /></b>} />
       <UT _str="<b>HTML text</b>" _tags="tag1" />
       <UT _str="<b>HTML inline text</b>" _inline />
+      <T _str={str3} />
       {msg}
+      {msg2}
     </div>
   );
 }


### PR DESCRIPTION
Add CLI support for detecting expressions such as:
```
const text = "Hello";
return <T _str={text} />;
```

Related to #61 