### PR TITLE
CLI: Extract value from template literals

### DIFF
--- a/packages/cli/src/api/extract.js
+++ b/packages/cli/src/api/extract.js
@@ -236,6 +236,16 @@ function findDeclaredValue(scope, init) {
     }
   }
 
+  if(init.type === 'TemplateLiteral') {
+    const expressions = init.expressions.map(node => findDeclaredValue(scope, node));
+    if (expressions.includes(null)) return null;
+
+    const elements = init.quasis.flatMap(
+      ({ tail, value }, i) => (tail ? value.raw : [value.raw, expressions[i]]),
+    );
+    return elements.join('');
+  }
+
   return null;
 }
 

--- a/packages/cli/src/api/extract.js
+++ b/packages/cli/src/api/extract.js
@@ -236,8 +236,8 @@ function findDeclaredValue(scope, init) {
     }
   }
 
-  if(init.type === 'TemplateLiteral') {
-    const expressions = init.expressions.map(node => findDeclaredValue(scope, node));
+  if (init.type === 'TemplateLiteral') {
+    const expressions = init.expressions.map((node) => findDeclaredValue(scope, node));
     if (expressions.includes(null)) return null;
 
     const elements = init.quasis.flatMap(

--- a/packages/cli/test/api/extract.test.js
+++ b/packages/cli/test/api/extract.test.js
@@ -277,6 +277,10 @@ describe('extractPhrases', () => {
           string: 'Inner Text',
           meta: { context: [], tags: [], occurrences: ['variables.js'] },
         },
+        '7c023dc6beb7e942ab667c8d32a488e7': {
+          string: 'Inner Text,Outer Text',
+          meta: { context: [], tags: [], occurrences: ['variables.js'] },
+        },
       });
   });
 

--- a/packages/cli/test/commands/push.test.js
+++ b/packages/cli/test/commands/push.test.js
@@ -6,7 +6,7 @@ describe('push command', () => {
     .stdout()
     .command(['push', 'test/fixtures/simple.js', '--dry-run'])
     .it('extracts simple phrases', (ctx) => {
-      expect(ctx.stdout).to.contain('Processed 1 file(s) and found 7 translatable phrases');
+      expect(ctx.stdout).to.contain('Processed 1 file(s) and found 8 translatable phrases');
       expect(ctx.stdout).to.contain('Content detected in 1 file(s)');
     });
 

--- a/packages/cli/test/fixtures/simple.js
+++ b/packages/cli/test/fixtures/simple.js
@@ -12,6 +12,7 @@ const text = 'foo';
 t(text);
 t('Text 1' + text);
 Instance.translate(text);
+Instance.translate(`templated text`);
 
 // invalid
 t('');
@@ -19,5 +20,4 @@ Instance.translateme('Text 5');
 Instance.translate();
 Instance.translate({ foo: 'bar' });
 Instance.translate(5);
-Instance.translate(`templated text`);
 Instance.translate('non-deterministic string' + 1);

--- a/packages/cli/test/fixtures/variables.js
+++ b/packages/cli/test/fixtures/variables.js
@@ -20,6 +20,7 @@ function foo() {
   log(t(merged));
   log(t(complicated));
   log(t(inner));
+  log(t(`${inner},${outer}`))
 
   const empty;
   let nonConst = 'should not be visible';


### PR DESCRIPTION
Hi!

I created some PoC for supporting ES6 template literals. It should support basic interpolations as covered by current variable lookups.

I thought cooked strings are not suitable for this usecase, but please edit if you think cooked one is more appropriate. The differences are stated [here](https://exploringjs.com/impatient-js/ch_template-literals.html#template-strings-cooked-vs-raw).