### PR TITLE
Angular SDK: Use CommonModule and not BrowserModule

### DIFF
--- a/packages/angular/projects/tx-native-angular-sdk/src/lib/TXNative.module.ts
+++ b/packages/angular/projects/tx-native-angular-sdk/src/lib/TXNative.module.ts
@@ -1,5 +1,5 @@
 import { ModuleWithProviders, NgModule } from '@angular/core';
-import { BrowserModule } from '@angular/platform-browser';
+import { CommonModule } from '@angular/common';
 
 import { LanguagePickerComponent } from './language-picker.component';
 import { TComponent } from './T.component';
@@ -14,7 +14,7 @@ import { TranslationService } from './translation.service';
     LanguagePickerComponent,
     SafeHtmlPipe,
   ],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   exports: [
     TComponent,
     UTComponent,


### PR DESCRIPTION
Importing TxNativeModule multiple times (multiple modules) gives error about BrowserModule loaded multiple times.

This just puts in CommonModule instead of BrowserModule.