### PR TITLE
CLI: try/catch parsing params

### DIFF
--- a/packages/cli/src/api/extract.js
+++ b/packages/cli/src/api/extract.js
@@ -108,8 +108,16 @@ const pipeBindingRegexp = /'([\s\S]+?)'\s*?\|\s*?translate\s*?:?({[\s\S]*?})?/i;
  * @returns {*}
  */
 function looseJsonParse(obj) {
-  // eslint-disable-next-line no-new-func
-  return Function(`"use strict";return (${obj})`)();
+  let parsed;
+
+  try {
+    // eslint-disable-next-line no-new-func
+    parsed = Function(`"use strict";return (${obj})`)();
+  } catch (err) {
+    parsed = {};
+  }
+
+  return parsed;
 }
 
 /**


### PR DESCRIPTION
Forgot to add a try/catch. 

When TranslatePipe has params that can not be found in current scope it will still allow the string to be pushed to Transifex.

Noticed you already did a release so I apologise :( 