### PR TITLE
Angular SDK: move vars to get/set

### DIFF
--- a/packages/angular/projects/tx-native-angular-sdk/src/lib/T.component.ts
+++ b/packages/angular/projects/tx-native-angular-sdk/src/lib/T.component.ts
@@ -59,7 +59,13 @@ export class TComponent implements OnInit, OnDestroy, OnChanges {
   sanitize?: boolean = false;
 
   @Input()
-  vars?: Record<string, unknown> = {};
+  get vars(): Record<string, unknown> {
+    return this.actualVars;
+  }
+
+  set vars(v: Record<string, unknown>) {
+    this.actualVars = { ...v };
+  }
 
   translateParams: ITranslateParams = {
     _key: '',
@@ -80,6 +86,8 @@ export class TComponent implements OnInit, OnDestroy, OnChanges {
   }
 
   localeChangeSubscription: Subscription;
+
+  private actualVars: Record<string, unknown> = {};
 
   /**
    * Constructor
@@ -140,6 +148,6 @@ export class TComponent implements OnInit, OnDestroy, OnChanges {
    */
   translate() {
     this.translatedStr = this.translationService.translate(this.str,
-      { ...this.translateParams, ...this.vars || {} });
+      { ...this.translateParams, ...this.vars });
   }
 }


### PR DESCRIPTION
Spreading the vars into actualVars should avoid any trouble when
someone does not provide the correct value.

In fact, Angular should do that as well. At least mine does.

This way we can get 100% on tests as there is no hidden branches.

I notices _vars was not an allowed name. I called it `actualVars`, any name change to conform to your style guide is welcome :)