### PR TITLE
Support for CDS API v2

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -111,6 +111,7 @@ DESCRIPTION
   txjs-cli push /home/repo/src
   txjs-cli push "*.js"
   txjs-cli push --dry-run
+  txjs-cli push --no-wait
   txjs-cli push --append-tags="master,release:2.5"
   txjs-cli push --with-tags-only="home,error"
   txjs-cli push --without-tags-only="custom"

--- a/packages/cli/src/api/extract.js
+++ b/packages/cli/src/api/extract.js
@@ -8,7 +8,7 @@ const _ = require('lodash');
 const path = require('path');
 const { generateKey } = require('@transifex/native');
 
-const mergePayload = require('./merge');
+const { mergePayload } = require('./merge');
 const { stringToArray, mergeArrays } = require('./utils');
 
 /**
@@ -499,4 +499,6 @@ function extractPhrases(file, relativeFile, options = {}) {
   return HASHES;
 }
 
-module.exports = extractPhrases;
+module.exports = {
+  extractPhrases,
+};

--- a/packages/cli/src/api/invalidate.js
+++ b/packages/cli/src/api/invalidate.js
@@ -10,38 +10,24 @@ const { version } = require('../../package.json');
  * @param {String} params.secret
  * @param {Boolean} params.purge
  * @returns {Object} Data
- * @returns {Boolean} Data.success
- * @returns {String} Data.status
- * @returns {Number} Data.data.count
- * @returns {Number} Data.data.status
- * @returns {Number} Data.data.token
+ * @returns {Number} Data.count
+ * @returns {Number} Data.status
+ * @returns {Number} Data.token
  */
 async function invalidateCDS(params) {
   const action = params.purge ? 'purge' : 'invalidate';
-  try {
-    const res = await axios.post(`${params.url}/${action}`, {
-    }, {
-      headers: {
-        Authorization: `Bearer ${params.token}:${params.secret}`,
-        'Content-Type': 'application/json;charset=utf-8',
-        'X-NATIVE-SDK': `txjs/cli/${version}`,
-      },
-    });
-    return {
-      success: true,
-      status: res.status,
-      data: res.data,
-    };
-  } catch (error) {
-    if (error.response) {
-      return {
-        success: false,
-        status: error.response.status,
-        data: error.response.data,
-      };
-    }
-    throw new Error(error.message);
-  }
+  const res = await axios.post(`${params.url}/${action}`, {
+  }, {
+    headers: {
+      Authorization: `Bearer ${params.token}:${params.secret}`,
+      'Accept-version': 'v2',
+      'Content-Type': 'application/json;charset=utf-8',
+      'X-NATIVE-SDK': `txjs/cli/${version}`,
+    },
+  });
+  return res.data;
 }
 
-module.exports = invalidateCDS;
+module.exports = {
+  invalidateCDS,
+};

--- a/packages/cli/src/api/merge.js
+++ b/packages/cli/src/api/merge.js
@@ -51,4 +51,6 @@ function mergePayload(parent, child) {
   return parent;
 }
 
-module.exports = mergePayload;
+module.exports = {
+  mergePayload,
+};

--- a/packages/cli/src/commands/invalidate.js
+++ b/packages/cli/src/commands/invalidate.js
@@ -3,7 +3,7 @@
 require('colors');
 const { Command, flags } = require('@oclif/command');
 const { cli } = require('cli-ux');
-const invalidateCDS = require('../api/invalidate');
+const { invalidateCDS } = require('../api/invalidate');
 
 class InvalidateCommand extends Command {
   async run() {
@@ -36,18 +36,12 @@ class InvalidateCommand extends Command {
         secret: projectSecret,
         purge: flags.purge,
       });
-      if (res.success) {
-        cli.action.stop('Success'.green);
-        this.log(`${(res.data.count || 0).toString().green} records invalidated`);
-        this.log('Note: It might take a few minutes for fresh content to be available'.yellow);
-      } else {
-        cli.action.stop('Failed'.red);
-        this.log(`Status code: ${res.status}`.red);
-        this.error(JSON.stringify(res.data));
-      }
+      cli.action.stop('Success'.green);
+      this.log(`${(res.data.count || 0).toString().green} records invalidated`);
+      this.log('Note: It might take a few minutes for fresh content to be available'.yellow);
     } catch (err) {
       cli.action.stop('Failed'.red);
-      throw err;
+      this.error(err);
     }
   }
 }

--- a/packages/cli/test/api/extract.test.js
+++ b/packages/cli/test/api/extract.test.js
@@ -1,7 +1,7 @@
 /* globals describe, it */
 
 const { expect } = require('chai');
-const extractPhrases = require('../../src/api/extract');
+const { extractPhrases } = require('../../src/api/extract');
 
 describe('extractPhrases', () => {
   it('works with webpack', async () => {
@@ -303,7 +303,7 @@ describe('extractPhrases', () => {
           string: 'This is a pipe text',
           meta: { context: [], tags: [], occurrences: ['angular-template.html'] },
         },
-        'def7319eabb4be374d5fae8ea5b79d55': {
+        def7319eabb4be374d5fae8ea5b79d55: {
           string: 'This is a second pipe text',
           meta: { context: [], tags: [], occurrences: ['angular-template.html'] },
         },
@@ -330,7 +330,7 @@ describe('extractPhrases', () => {
         'text.pipe_binding': {
           string: 'Used in a second binding',
           meta: { context: [], tags: [], occurrences: ['angular-template.html'] },
-        }
+        },
       });
   });
 });

--- a/packages/cli/test/api/merge.test.js
+++ b/packages/cli/test/api/merge.test.js
@@ -1,7 +1,7 @@
 /* globals describe, it */
 
 const { expect } = require('chai');
-const mergePayload = require('../../src/api/merge');
+const { mergePayload } = require('../../src/api/merge');
 
 describe('mergePayload', () => {
   it('merges json', async () => {

--- a/packages/cli/test/commands/invalidate.test.js
+++ b/packages/cli/test/commands/invalidate.test.js
@@ -6,9 +6,11 @@ describe('invalidate command', () => {
     .nock('https://cds.svc.transifex.net', (api) => api
       .post('/invalidate')
       .reply(200, {
-        status: 'success',
-        token: 't',
-        count: 5,
+        data: {
+          status: 'success',
+          token: 't',
+          count: 5,
+        },
       }))
     .stdout()
     .command(['invalidate', '--secret=s', '--token=t'])
@@ -20,9 +22,11 @@ describe('invalidate command', () => {
     .nock('https://cds.svc.transifex.net', (api) => api
       .post('/purge')
       .reply(200, {
-        status: 'success',
-        token: 't',
-        count: 10,
+        data: {
+          status: 'success',
+          token: 't',
+          count: 10,
+        },
       }))
     .stdout()
     .command(['invalidate', '--purge', '--secret=s', '--token=t'])
@@ -39,6 +43,6 @@ describe('invalidate command', () => {
     .command(['invalidate', '--secret=s', '--token=t'])
     .exit(2)
     .it('handles invalidate error', (ctx) => {
-      expect(ctx.stdout).to.contain('Status code: 403');
+      expect(ctx.stdout).to.contain('Invalidating CDS cache... Failed');
     });
 });

--- a/packages/cli/test/commands/push.test.js
+++ b/packages/cli/test/commands/push.test.js
@@ -72,12 +72,27 @@ describe('push command', () => {
     .nock('https://cds.svc.transifex.net', (api) => api
       .post('/content')
       .reply(200, {
-        created: 2,
-        updated: 2,
-        skipped: 0,
-        deleted: 0,
-        failed: 0,
-        errors: [],
+        data: {
+          id: '1',
+          links: {
+            job: '/jobs/content/1',
+          },
+        },
+      }))
+    .nock('https://cds.svc.transifex.net', (api) => api
+      .get('/jobs/content/1')
+      .reply(200, {
+        data: {
+          details: {
+            created: 2,
+            updated: 2,
+            skipped: 0,
+            deleted: 0,
+            failed: 0,
+          },
+          errors: [],
+          status: 'completed',
+        },
       }))
     .stdout()
     .command(['push', 'test/fixtures/simple.js', '--secret=s', '--token=t'])
@@ -95,6 +110,6 @@ describe('push command', () => {
     .command(['push', 'test/fixtures/simple.js', '--secret=s', '--token=t'])
     .exit(2)
     .it('handles push error', (ctx) => {
-      expect(ctx.stdout).to.contain('Status code: 403');
+      expect(ctx.stdout).to.contain('Uploading content to Transifex... Failed');
     });
 });

--- a/packages/native/src/TxNative.js
+++ b/packages/native/src/TxNative.js
@@ -167,6 +167,7 @@ export default class TxNative {
         response = await axios.get(url, {
           headers: {
             Authorization: `Bearer ${this.token}`,
+            'Accept-version': 'v2',
             'X-NATIVE-SDK': `txjs/${__PLATFORM__}/${__VERSION__}`,
           },
         });
@@ -220,6 +221,7 @@ export default class TxNative {
         response = await axios.get(`${this.cdsHost}/languages`, {
           headers: {
             Authorization: `Bearer ${this.token}`,
+            'Accept-version': 'v2',
             'X-NATIVE-SDK': `txjs/${__PLATFORM__}/${__VERSION__}`,
           },
         });


### PR DESCRIPTION
Make SDK compatible with related [breaking changes](https://github.com/transifex/transifex-delivery/releases/tag/0.14.0) on CDS service:
- CLI: Enable async push of content and poll for upload results
- CLI: Update invalidation/purge responses related to new CDS version
- Add "Accept-version: v2" header on all requests to CDS