### PR TITLE
extract: T/UT is supposed to have no underscore in attributes

### DIFF
--- a/packages/cli/src/api/extract.js
+++ b/packages/cli/src/api/extract.js
@@ -36,10 +36,12 @@ function createPayload(string, params, occurence, appendTags) {
     string,
     key: generateKey(string, params),
     meta: _.omitBy({
-      context: stringToArray(params._context),
-      developer_comment: params._comment,
-      character_limit: params._charlimit ? parseInt(params._charlimit, 10) : undefined,
-      tags: mergeArrays(stringToArray(params._tags), appendTags),
+      context: stringToArray(params._context || params.context),
+      developer_comment: params._comment || params.comment,
+      character_limit: params._charlimit || params.charlimit
+        ? parseInt(params._charlimit || params.charlimit, 10)
+        : undefined,
+      tags: mergeArrays(stringToArray(params._tags || params.tags), appendTags),
       occurrences: [occurence],
     }, _.isNil),
   };

--- a/packages/cli/test/api/extract.test.js
+++ b/packages/cli/test/api/extract.test.js
@@ -331,6 +331,14 @@ describe('extractPhrases', () => {
           string: 'Used in a second binding',
           meta: { context: [], tags: [], occurrences: ['angular-template.html'] },
         },
+        'content.is-text': {
+          string: 'This is a text with a context, and it should be recognized as one',
+          meta: { context: ['is-text'], tags: [], occurrences: ['angular-template.html'] },
+        },
+        'content.is-text': {
+          string: 'This is a text with a context, and it should be recognized as one',
+          meta: { context: ['is-text'], tags: [], occurrences: ['angular-template.html'] },
+        },
       });
   });
 });

--- a/packages/cli/test/fixtures/angular-template.html
+++ b/packages/cli/test/fixtures/angular-template.html
@@ -64,4 +64,9 @@
   <p [matTooltip]="'Used in a second binding'|translate:{key: 'text.pipe_binding', _secondParam: true, _thirdParams:false }">
     Inside a p
   </p>
+
+  <T str="This is a text with a context, and it should be recognized as one"
+    key="content.is-text"
+    context="is-text">
+  </T>
 </div>


### PR DESCRIPTION
This one just adds a fallback for _context (context), _comment (comment), _charlimit (charlimit) and _tags (tags) so that usage of T and UT will get it's params out.

According to the documentation for Angular the params are without _ on the Angular T / UT component. This was handled for key but not for the other ones that are sent to Transifex. I should have seen it before :(

Includes one test to check that it does correct for _context, the rest just follows the same logic.