### PR TITLE
Angular SDK: T component should get params each time

### DIFF
--- a/packages/angular/projects/tx-native-angular-sdk/src/lib/T.component.ts
+++ b/packages/angular/projects/tx-native-angular-sdk/src/lib/T.component.ts
@@ -67,16 +67,18 @@ export class TComponent implements OnInit, OnDestroy, OnChanges {
     this.actualVars = { ...v };
   }
 
-  translateParams: ITranslateParams = {
-    _key: '',
-    _context: '',
-    _comment: '',
-    _charlimit: 0,
-    _tags: '',
-    _escapeVars: false,
-    _inline: false,
-    sanitize: false,
-  };
+  get translateParams(): ITranslateParams {
+    return {
+      _key: this.key,
+      _context: this.context,
+      _comment: this.comment,
+      _charlimit: this.charlimit,
+      _tags: this.tags,
+      _escapeVars: this.escapeVars,
+      _inline: this.inline,
+      sanitize: this.sanitize,
+    };
+  }
 
   translatedStr = '';
 
@@ -97,7 +99,6 @@ export class TComponent implements OnInit, OnDestroy, OnChanges {
   constructor(protected translationService: TranslationService) {
     this.localeChangeSubscription = this.localeChanged.subscribe(
       (locale) => {
-        this.setTranslateParams();
         this.translate();
       },
     );
@@ -107,7 +108,6 @@ export class TComponent implements OnInit, OnDestroy, OnChanges {
    * Component initialization
    */
   ngOnInit() {
-    this.setTranslateParams();
     this.translate();
   }
 
@@ -125,22 +125,6 @@ export class TComponent implements OnInit, OnDestroy, OnChanges {
    */
   ngOnChanges(changes: SimpleChanges) {
     this.translate();
-  }
-
-  /**
-   * Set translation params
-   */
-  setTranslateParams() {
-    Object.assign(this.translateParams, {
-      _key: this.key,
-      _context: this.context,
-      _comment: this.comment,
-      _charlimit: this.charlimit,
-      _tags: this.tags,
-      _escapeVars: this.escapeVars,
-      _inline: this.inline,
-      sanitize: this.sanitize,
-    });
   }
 
   /**

--- a/packages/angular/projects/tx-native-angular-sdk/tests/T.component.spec.ts
+++ b/packages/angular/projects/tx-native-angular-sdk/tests/T.component.spec.ts
@@ -183,4 +183,27 @@ describe('TComponent', () => {
       { ...translationParams, _key: 'key-not-translated' });
     expect(component.translatedStr).toEqual('translated-again');
   });
+
+  it('should respect changes to input params', async () => {
+    // setup
+    spyOn(service, 'translate').and.returnValue('translated');
+
+    // act
+    component.str = 'not-translated';
+    component.key = 'key-not-translated';
+    component.ngOnInit();
+    fixture.detectChanges();
+
+    component.context = 'late';
+    component.ngOnChanges({});
+    fixture.detectChanges();
+
+    // assert
+    expect(service.translate).toHaveBeenCalledWith('not-translated', {
+      ...translationParams,
+      _key: 'key-not-translated',
+      _context: 'late',
+    });
+    expect(component.translatedStr).toEqual('translated');
+  });
 });


### PR DESCRIPTION
Any change to Input() was ignored. This just changes translationParams
to a getter so that it gets what the component has set at the time of
translation.