### PR TITLE
'useT' hook to return function

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -112,9 +112,8 @@ properties with the `T` component._
 
 ### `useT` hook
 
-Returns a state variable that will be automatically updated when the selected
-language changes. Used internally by the `T` and `UT` components. Accepts the
-same props as the `T` component.
+Makes the current component re-render when a language change is detected and
+returns a t-function you can use to translate strings programmatically.
 
 You will most likely prefer to use the `T` or `UT` components over this, unless
 for some reason you want to have the translation output in a variable for
@@ -126,7 +125,8 @@ import React from 'react';
 import { useT } from '@transifex/react';
 
 function Capitalized() {
-  const message = useT('Hello world');
+  const t = useT();
+  const message = t('Hello world');
   return <span>{message.toUpperCase()}</span>;
 }
 ```

--- a/packages/react/src/components/T.jsx
+++ b/packages/react/src/components/T.jsx
@@ -22,7 +22,7 @@ import useT from '../hooks/useT';
  * } */
 
 export default function T({ _str, ...props }) {
-  return useT(_str, props);
+  return useT()(_str, props);
 }
 
 T.defaultProps = {};

--- a/packages/react/src/components/UT.jsx
+++ b/packages/react/src/components/UT.jsx
@@ -19,7 +19,7 @@ import useT from '../hooks/useT';
  * */
 
 export default function UT({ _str, _inline, ...props }) {
-  const translation = useT(
+  const translation = useT()(
     _str,
     { _inline, _escapeVars: true, ...props },
   );

--- a/packages/react/src/hooks/useT.js
+++ b/packages/react/src/hooks/useT.js
@@ -2,9 +2,8 @@ import { useEffect, useState } from 'react';
 import { onEvent, offEvent, LOCALE_CHANGED } from '@transifex/native';
 import translateWithElements from '../utils/translateWithElements';
 
-/* Return a state variable with the translation of `_str` against props. In
- * case the language changes, the variable will be updated, causing the
- * component that uses it to be rerendered.
+/* Return a reference of the 'translateWithElements' function. Also forces the
+ * component to re-render in case the language changes.
  *
  * In most cases, we expect you to prefer using the `T` component over this,
  * but if you want to save the translation outcome in a variable for
@@ -13,11 +12,12 @@ import translateWithElements from '../utils/translateWithElements';
  * Usage
  *
  * function Capitalized({ _str, ...props }) {
- *   const translation = useT(_str, props);
+ *   const t = useT();
+ *   const translation = t(_str, props);
  *   return <span>{translation.toUpperCase()}</span>;
  * } */
 
-export default function useT(_str, props) {
+export default function useT() {
   const [, setCounter] = useState(0);
   useEffect(() => {
     // Using `setCounter` will trigger a rerender
@@ -25,5 +25,5 @@ export default function useT(_str, props) {
     onEvent(LOCALE_CHANGED, rerender);
     return () => { offEvent(LOCALE_CHANGED, rerender); };
   }, [setCounter]);
-  return translateWithElements(_str, props);
+  return translateWithElements;
 }

--- a/packages/react/tests/useT.test.js
+++ b/packages/react/tests/useT.test.js
@@ -16,7 +16,8 @@ describe('useT', () => {
 
   it('renders text', () => {
     function MyComp() {
-      const message = useT('Hello <b>safe text</b>');
+      const t = useT();
+      const message = t('Hello <b>safe text</b>');
       return (message);
     }
 
@@ -26,7 +27,8 @@ describe('useT', () => {
 
   it('renders text with param', () => {
     function MyComp() {
-      const message = useT('Hello <b>{username}</b>', {
+      const t = useT();
+      const message = t('Hello <b>{username}</b>', {
         username: 'JohnDoe',
       });
       return (message);
@@ -39,9 +41,8 @@ describe('useT', () => {
   it('rerenders on prop change', () => {
     const MyComp = () => {
       const [word, setWord] = useState('');
-      const message = useT('hello {word}', {
-        word,
-      });
+      const t = useT();
+      const message = t('hello {word}', { word });
       return (
         <>
           <input value={word} onChange={(e) => setWord(e.target.value)} />
@@ -60,9 +61,8 @@ describe('useT', () => {
   it('renders react elements', () => {
     const MyComp = () => {
       const [word, setWord] = useState('');
-      const message = useT('hello {w}', {
-        w: <b>world</b>,
-      });
+      const t = useT();
+      const message = t('hello {w}', { w: <b>world</b> });
       return (
         <>
           <input value={word} onChange={(e) => setWord(e.target.value)} />


### PR DESCRIPTION
Note: This is a breaking change and should be communicated as such!!! Fortunately, I doubt many users are using 'useT' at the moment so we should be ok.

The previous 'useT' implementation returned the translated string. The problem was that, since it's a hook, it must be used at the top of a component before any control flows. So this would be dangerous:

```javascript
function AComponent({ ... }) {
  if (something) {
    doSomething();
  } else {
    doSomethingElse();
  }
  const message = useT(...);
  return <b>{message}<b>
}
```

since if any hooks are used in the if/else block, it would affect the order with which the hooks are used. In fact, I suspect that eslint can raise an error if the above snippet is used.

This implementation:

1. Forces the current component to rerender when the language changes
2. Returns a reference to 'translateWithElements'

Side note: this is more in line with what react-i18next offers.

The correct way of using useT after this is that instead of:

```javascript
function MyComponent() {
  const message = useT('Hello world');
  return message;
}
```

You should write this

```javascript
function MyComponent() {
  const t = useT();
  const message = t('Hello world');
  return message;
}
```