### PR TITLE
Add support for source based keys in native & cli

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -85,6 +85,8 @@ OPTIONS
   --append-tags=append-tags              append tags to strings
   --cds-host=cds-host                    CDS host URL
   --dry-run                              dry run, do not push to Transifex
+  --key-generator=source|hash            [default: source] use hashed or source based keys
+  --no-wait                              disable polling for upload results
   --purge                                purge content on Transifex
   --secret=secret                        native project secret
   --token=token                          native project public token
@@ -92,7 +94,7 @@ OPTIONS
   --without-tags-only=without-tags-only  push strings without specific tags
 
 DESCRIPTION
-  Parse .js, .ts, .jsx and .tsx files and detect phrases marked for
+  Parse .js, .ts, .jsx, .tsx and .html files and detect phrases marked for
   translation by Transifex Native toolkit for Javascript and
   upload them to Transifex for translation.
 
@@ -112,6 +114,7 @@ DESCRIPTION
   txjs-cli push "*.js"
   txjs-cli push --dry-run
   txjs-cli push --no-wait
+  txjs-cli push --key-generator=hash
   txjs-cli push --append-tags="master,release:2.5"
   txjs-cli push --with-tags-only="home,error"
   txjs-cli push --without-tags-only="custom"

--- a/packages/cli/src/commands/push.js
+++ b/packages/cli/src/commands/push.js
@@ -44,6 +44,7 @@ class PushCommand extends Command {
     const appendTags = stringToArray(flags['append-tags']);
     const filterWithTags = stringToArray(flags['with-tags-only']);
     const filterWithoutTags = stringToArray(flags['without-tags-only']);
+    const useHashedKeys = flags['key-generator'] === 'hash';
 
     this.log('Parsing all files to detect translatable content...');
 
@@ -71,6 +72,7 @@ class PushCommand extends Command {
       appendTags,
       filterWithTags,
       filterWithoutTags,
+      useHashedKeys,
     };
 
     _.each(allFiles, (file) => {
@@ -244,6 +246,7 @@ txjs-cli push /home/repo/src
 txjs-cli push "*.js"
 txjs-cli push --dry-run
 txjs-cli push --no-wait
+txjs-cli push --key-generator=hash
 txjs-cli push --append-tags="master,release:2.5"
 txjs-cli push --with-tags-only="home,error"
 txjs-cli push --without-tags-only="custom"
@@ -299,6 +302,11 @@ PushCommand.flags = {
   'cds-host': flags.string({
     description: 'CDS host URL',
     default: '',
+  }),
+  'key-generator': flags.string({
+    description: 'use hashed or source based keys',
+    default: 'source',
+    options: ['source', 'hash'],
   }),
 };
 

--- a/packages/cli/test/api/extract.hashedkeys.test.js
+++ b/packages/cli/test/api/extract.hashedkeys.test.js
@@ -1,0 +1,361 @@
+/* globals describe, it */
+
+const { expect } = require('chai');
+const { extractPhrases } = require('../../src/api/extract');
+
+describe('extractPhrases with hashed keys', () => {
+  it('works with webpack', async () => {
+    expect(await extractPhrases('test/fixtures/webpack.js', 'webpack.js', {
+      useHashedKeys: true,
+    }))
+      .to.deep.equal({
+        '6f48100ca5a57d2db9b685a8373be8a6': {
+          string: 'Text 1',
+          meta: {
+            character_limit: 10,
+            context: ['foo'],
+            tags: ['tag1', 'tag2'],
+            developer_comment: 'comment',
+            occurrences: ['webpack.js'],
+          },
+        },
+        '5d47152bcd597dd6adbff4884374aaad': {
+          string: 'Text 2',
+          meta: { context: [], tags: [], occurrences: ['webpack.js'] },
+        },
+        '3cd62915590816fdbf53852e44ee675a': {
+          string: 'Text 3',
+          meta: { context: [], tags: [], occurrences: ['webpack.js'] },
+        },
+        '33f5afa925f1464280d72d6d9086057c': {
+          string: 'Text 4',
+          meta: { context: [], tags: [], occurrences: ['webpack.js'] },
+        },
+      });
+  });
+
+  it('works with append tags', async () => {
+    expect(await extractPhrases('test/fixtures/webpack.js', 'webpack.js', {
+      useHashedKeys: true,
+      appendTags: ['g1', 'g2'],
+    }))
+      .to.deep.equal({
+        '6f48100ca5a57d2db9b685a8373be8a6': {
+          string: 'Text 1',
+          meta: {
+            character_limit: 10,
+            context: ['foo'],
+            tags: ['tag1', 'tag2', 'g1', 'g2'],
+            developer_comment: 'comment',
+            occurrences: ['webpack.js'],
+          },
+        },
+        '5d47152bcd597dd6adbff4884374aaad': {
+          string: 'Text 2',
+          meta: { context: [], tags: ['g1', 'g2'], occurrences: ['webpack.js'] },
+        },
+        '3cd62915590816fdbf53852e44ee675a': {
+          string: 'Text 3',
+          meta: { context: [], tags: ['g1', 'g2'], occurrences: ['webpack.js'] },
+        },
+        '33f5afa925f1464280d72d6d9086057c': {
+          string: 'Text 4',
+          meta: { context: [], tags: ['g1', 'g2'], occurrences: ['webpack.js'] },
+        },
+      });
+  });
+
+  it('works with node', async () => {
+    expect(await extractPhrases('test/fixtures/node.js', 'node.js', {
+      useHashedKeys: true,
+    }))
+      .to.deep.equal({
+        '6f48100ca5a57d2db9b685a8373be8a6': {
+          string: 'Text 1',
+          meta: {
+            character_limit: 10,
+            context: ['foo'],
+            tags: ['tag1', 'tag2'],
+            developer_comment: 'comment',
+            occurrences: ['node.js'],
+          },
+        },
+        '5d47152bcd597dd6adbff4884374aaad': {
+          string: 'Text 2',
+          meta: { context: [], tags: [], occurrences: ['node.js'] },
+        },
+        '3cd62915590816fdbf53852e44ee675a': {
+          string: 'Text 3',
+          meta: { context: [], tags: [], occurrences: ['node.js'] },
+        },
+        '33f5afa925f1464280d72d6d9086057c': {
+          string: 'Text 4',
+          meta: { context: [], tags: [], occurrences: ['node.js'] },
+        },
+      });
+  });
+
+  it('works with jsx', async () => {
+    expect(await extractPhrases('test/fixtures/react.jsx', 'react.jsx', {
+      useHashedKeys: true,
+    }))
+      .to.deep.equal({
+        a8b326ca0f8eacfd2ecf1140a860fccc: {
+          string: 'uses useT',
+          meta: { context: [], tags: [], occurrences: ['react.jsx'] },
+        },
+        '41ea834f9604545bba088de53e71a159': {
+          string: 'uses useT as const',
+          meta: { context: [], tags: [], occurrences: ['react.jsx'] },
+        },
+        '14a6af017c176654aaf0df13d1179418': {
+          string: 'uses _str as const',
+          meta: { context: [], tags: [], occurrences: ['react.jsx'] },
+        },
+        '6f48100ca5a57d2db9b685a8373be8a6': {
+          string: 'Text 1',
+          meta: {
+            character_limit: 10,
+            context: ['foo'],
+            tags: ['tag1', 'tag2'],
+            developer_comment: 'comment',
+            occurrences: ['react.jsx'],
+          },
+        },
+        '5d47152bcd597dd6adbff4884374aaad': {
+          string: 'Text 2',
+          meta: { context: [], tags: [], occurrences: ['react.jsx'] },
+        },
+        '3cd62915590816fdbf53852e44ee675a': {
+          string: 'Text 3',
+          meta: { context: [], tags: [], occurrences: ['react.jsx'] },
+        },
+        '33f5afa925f1464280d72d6d9086057c': {
+          string: 'Text 4',
+          meta: { context: [], tags: [], occurrences: ['react.jsx'] },
+        },
+        '90da95711d6dc69953b2978d2bed9b7d': {
+          string: 'A {button} and a {bold} walk into a bar',
+          meta: { context: [], tags: [], occurrences: ['react.jsx'] },
+        },
+        a667d8741bde4f79971b6220a0c0b647: {
+          string: 'button',
+          meta: { context: [], tags: [], occurrences: ['react.jsx'] },
+        },
+        e5f9dda0c39f13357321d0c07bb7a3ff: {
+          string: 'bold',
+          meta: { context: [], tags: [], occurrences: ['react.jsx'] },
+        },
+        '16c514ade457a04f8a5e074fe705fd09': {
+          string: '<b>HTML text</b>',
+          meta: { context: [], tags: ['tag1'], occurrences: ['react.jsx'] },
+        },
+        ff6354c17646535001825818343d64f3: {
+          string: '<b>HTML inline text</b>',
+          meta: { context: [], tags: [], occurrences: ['react.jsx'] },
+        },
+      });
+  });
+
+  it('works with tsx', async () => {
+    expect(await extractPhrases('test/fixtures/react.tsx', 'react.tsx', {
+      useHashedKeys: true,
+    }))
+      .to.deep.equal({
+        '6f48100ca5a57d2db9b685a8373be8a6': {
+          string: 'Text 1',
+          meta: {
+            character_limit: 10,
+            context: ['foo'],
+            tags: ['tag1', 'tag2'],
+            developer_comment: 'comment',
+            occurrences: ['react.tsx'],
+          },
+        },
+        '5d47152bcd597dd6adbff4884374aaad': {
+          string: 'Text 2',
+          meta: { context: [], tags: [], occurrences: ['react.tsx'] },
+        },
+        '3cd62915590816fdbf53852e44ee675a': {
+          string: 'Text 3',
+          meta: { context: [], tags: [], occurrences: ['react.tsx'] },
+        },
+        '33f5afa925f1464280d72d6d9086057c': {
+          string: 'Text 4',
+          meta: { context: [], tags: [], occurrences: ['react.tsx'] },
+        },
+        '90da95711d6dc69953b2978d2bed9b7d': {
+          string: 'A {button} and a {bold} walk into a bar',
+          meta: { context: [], tags: [], occurrences: ['react.tsx'] },
+        },
+        a667d8741bde4f79971b6220a0c0b647: {
+          string: 'button',
+          meta: { context: [], tags: [], occurrences: ['react.tsx'] },
+        },
+        e5f9dda0c39f13357321d0c07bb7a3ff: {
+          string: 'bold',
+          meta: { context: [], tags: [], occurrences: ['react.tsx'] },
+        },
+        '16c514ade457a04f8a5e074fe705fd09': {
+          string: '<b>HTML text</b>',
+          meta: { context: [], tags: ['tag1'], occurrences: ['react.tsx'] },
+        },
+        ff6354c17646535001825818343d64f3: {
+          string: '<b>HTML inline text</b>',
+          meta: { context: [], tags: [], occurrences: ['react.tsx'] },
+        },
+      });
+  });
+
+  it('works with typescript', async () => {
+    expect(await extractPhrases('test/fixtures/typescript.ts', 'typescript.ts', {
+      useHashedKeys: true,
+    }))
+      .to.deep.equal({
+        'text.monday': {
+          string: 'Monday',
+          meta: { context: [], tags: [], occurrences: ['typescript.ts'] },
+        },
+        d3b72592c4af5b55aac2dd0c88a9422a: {
+          string: 'Shoes',
+          meta: { context: [], tags: [], occurrences: ['typescript.ts'] },
+        },
+      });
+  });
+
+  it('works with decorators', async () => {
+    expect(await extractPhrases('test/fixtures/decorators.js', 'decorators.js', {
+      useHashedKeys: true,
+    }))
+      .to.deep.equal({
+        bc077c881a53b3575ffe7eaf390ffca4: {
+          string: 'Component with decorator',
+          meta: { context: [], tags: [], occurrences: ['decorators.js'] },
+        },
+        d1695cddb12ea34290ad14c90bc88a39: {
+          string: 'TestClass1 example',
+          meta: { context: [], tags: [], occurrences: ['decorators.js'] },
+        },
+        cf24b3ddbdaaa21f7aba79187ef01f63: {
+          string: 'TestClass2 example',
+          meta: { context: [], tags: [], occurrences: ['decorators.js'] },
+        },
+        d18654e576453293d60dbb2833b914f3: {
+          string: 'TestClass3 example',
+          meta: { context: [], tags: [], occurrences: ['decorators.js'] },
+        },
+      });
+  });
+
+  it('works with class properties', async () => {
+    expect(await extractPhrases('test/fixtures/classproperties.js', 'classproperties.js', {
+      useHashedKeys: true,
+    }))
+      .to.deep.equal({
+        '4f8d30aecb6784371423169bd67067f4': {
+          string: 'Static Property text',
+          meta: { context: [], tags: [], occurrences: ['classproperties.js'] },
+        },
+        '6eb781ad9f94e72e7e3e1eb8d84e9b23': {
+          string: 'Instance property text',
+          meta: { context: [], tags: [], occurrences: ['classproperties.js'] },
+        },
+        a5341bc1ed5a4c2278f50fa60cd359c9: {
+          string: 'Static Function text',
+          meta: { context: [], tags: [], occurrences: ['classproperties.js'] },
+        },
+      });
+  });
+
+  it('works with const identifiers', async () => {
+    expect(await extractPhrases('test/fixtures/variables.js', 'variables.js', {
+      useHashedKeys: true,
+    }))
+      .to.deep.equal({
+        '5d34b0b02c893763b0679f0aeab472ae': {
+          string: 'abc',
+          meta: { context: [], tags: [], occurrences: ['variables.js'] },
+        },
+        '06af01ed1976798d82a569a6e0af7537': {
+          string: 'Outer Text',
+          meta: { context: [], tags: [], occurrences: ['variables.js'] },
+        },
+        f089f645d1baa0ce4f398a4388520de3: {
+          string: ' Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text',
+          meta: { context: [], tags: [], occurrences: ['variables.js'] },
+        },
+        ac186ba33ab07d1ba8864f15662c308c: {
+          string: 'Outer Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text',
+          meta: { context: [], tags: [], occurrences: ['variables.js'] },
+        },
+        e5609fd3ccf5a0e9eea07d2a0918c2bd: {
+          string: 'abcdefg',
+          meta: { context: [], tags: [], occurrences: ['variables.js'] },
+        },
+        '3a2a11e5b86fdb8e2807170eca54171f': {
+          string: 'Inner Text',
+          meta: { context: [], tags: [], occurrences: ['variables.js'] },
+        },
+        '7c023dc6beb7e942ab667c8d32a488e7': {
+          string: 'Inner Text,Outer Text',
+          meta: { context: [], tags: [], occurrences: ['variables.js'] },
+        },
+      });
+  });
+
+  it('works with angular html templates', async () => {
+    expect(await extractPhrases('test/fixtures/angular-template.html', 'angular-template.html', {
+      useHashedKeys: true,
+    }))
+      .to.deep.equal({
+        'text.agree_message': {
+          string: 'By proceeding you agree to the {terms_of_services} and {privacy_policy}.',
+          meta: { context: [], tags: [], occurrences: ['angular-template.html'] },
+        },
+        'text.intro_message': {
+          string: 'It’s {weekday} today, and it is a fine day to try out Native! Checkout the offering below!',
+          meta: { context: [], tags: [], occurrences: ['angular-template.html'] },
+        },
+        'text.main_title': {
+          string: 'This is a test',
+          meta: { context: [], tags: [], occurrences: ['angular-template.html'] },
+        },
+        'text.pipe_text': {
+          string: 'This is a pipe text',
+          meta: { context: [], tags: [], occurrences: ['angular-template.html'] },
+        },
+        def7319eabb4be374d5fae8ea5b79d55: {
+          string: 'This is a second pipe text',
+          meta: { context: [], tags: [], occurrences: ['angular-template.html'] },
+        },
+        '9eae72bb80f1d30adc39a97c56eb2f6b': {
+          string: '\n      This is a\n      third pipe text\n      ',
+          meta: { context: [], tags: [], occurrences: ['angular-template.html'] },
+        },
+        'text.pipe_text_fourth': {
+          string: 'This is a fourth pipe text',
+          meta: { context: [], tags: [], occurrences: ['angular-template.html'] },
+        },
+        'text.fifth': {
+          string: 'It’s {weekday} today, and it is a fine day to try out Native!',
+          meta: { context: [], tags: [], occurrences: ['angular-template.html'] },
+        },
+        'text.pipe_text_sixth': {
+          string: 'This is a sixth pipe text, no one should do this',
+          meta: { context: [], tags: [], occurrences: ['angular-template.html'] },
+        },
+        '867b7cc4643da9b4c97ababa43c50c23': {
+          string: 'Used in a {binding}',
+          meta: { context: [], tags: [], occurrences: ['angular-template.html'] },
+        },
+        'text.pipe_binding': {
+          string: 'Used in a second binding',
+          meta: { context: [], tags: [], occurrences: ['angular-template.html'] },
+        },
+        'content.is-text': {
+          string: 'This is a text with a context, and it should be recognized as one',
+          meta: { context: ['is-text'], tags: [], occurrences: ['angular-template.html'] },
+        },
+      });
+  });
+});

--- a/packages/cli/test/api/extract.sourcekeys.test.js
+++ b/packages/cli/test/api/extract.sourcekeys.test.js
@@ -3,11 +3,11 @@
 const { expect } = require('chai');
 const { extractPhrases } = require('../../src/api/extract');
 
-describe('extractPhrases', () => {
+describe('extractPhrases with source keys', () => {
   it('works with webpack', async () => {
     expect(await extractPhrases('test/fixtures/webpack.js', 'webpack.js'))
       .to.deep.equal({
-        '6f48100ca5a57d2db9b685a8373be8a6': {
+        'Text 1::foo': {
           string: 'Text 1',
           meta: {
             character_limit: 10,
@@ -17,15 +17,15 @@ describe('extractPhrases', () => {
             occurrences: ['webpack.js'],
           },
         },
-        '5d47152bcd597dd6adbff4884374aaad': {
+        'Text 2': {
           string: 'Text 2',
           meta: { context: [], tags: [], occurrences: ['webpack.js'] },
         },
-        '3cd62915590816fdbf53852e44ee675a': {
+        'Text 3': {
           string: 'Text 3',
           meta: { context: [], tags: [], occurrences: ['webpack.js'] },
         },
-        '33f5afa925f1464280d72d6d9086057c': {
+        'Text 4': {
           string: 'Text 4',
           meta: { context: [], tags: [], occurrences: ['webpack.js'] },
         },
@@ -33,9 +33,11 @@ describe('extractPhrases', () => {
   });
 
   it('works with append tags', async () => {
-    expect(await extractPhrases('test/fixtures/webpack.js', 'webpack.js', { appendTags: ['g1', 'g2'] }))
+    expect(await extractPhrases('test/fixtures/webpack.js', 'webpack.js', {
+      appendTags: ['g1', 'g2'],
+    }))
       .to.deep.equal({
-        '6f48100ca5a57d2db9b685a8373be8a6': {
+        'Text 1::foo': {
           string: 'Text 1',
           meta: {
             character_limit: 10,
@@ -45,15 +47,15 @@ describe('extractPhrases', () => {
             occurrences: ['webpack.js'],
           },
         },
-        '5d47152bcd597dd6adbff4884374aaad': {
+        'Text 2': {
           string: 'Text 2',
           meta: { context: [], tags: ['g1', 'g2'], occurrences: ['webpack.js'] },
         },
-        '3cd62915590816fdbf53852e44ee675a': {
+        'Text 3': {
           string: 'Text 3',
           meta: { context: [], tags: ['g1', 'g2'], occurrences: ['webpack.js'] },
         },
-        '33f5afa925f1464280d72d6d9086057c': {
+        'Text 4': {
           string: 'Text 4',
           meta: { context: [], tags: ['g1', 'g2'], occurrences: ['webpack.js'] },
         },
@@ -63,7 +65,7 @@ describe('extractPhrases', () => {
   it('works with node', async () => {
     expect(await extractPhrases('test/fixtures/node.js', 'node.js'))
       .to.deep.equal({
-        '6f48100ca5a57d2db9b685a8373be8a6': {
+        'Text 1::foo': {
           string: 'Text 1',
           meta: {
             character_limit: 10,
@@ -73,15 +75,15 @@ describe('extractPhrases', () => {
             occurrences: ['node.js'],
           },
         },
-        '5d47152bcd597dd6adbff4884374aaad': {
+        'Text 2': {
           string: 'Text 2',
           meta: { context: [], tags: [], occurrences: ['node.js'] },
         },
-        '3cd62915590816fdbf53852e44ee675a': {
+        'Text 3': {
           string: 'Text 3',
           meta: { context: [], tags: [], occurrences: ['node.js'] },
         },
-        '33f5afa925f1464280d72d6d9086057c': {
+        'Text 4': {
           string: 'Text 4',
           meta: { context: [], tags: [], occurrences: ['node.js'] },
         },
@@ -91,19 +93,19 @@ describe('extractPhrases', () => {
   it('works with jsx', async () => {
     expect(await extractPhrases('test/fixtures/react.jsx', 'react.jsx'))
       .to.deep.equal({
-        a8b326ca0f8eacfd2ecf1140a860fccc: {
+        'uses useT': {
           string: 'uses useT',
           meta: { context: [], tags: [], occurrences: ['react.jsx'] },
         },
-        '41ea834f9604545bba088de53e71a159': {
+        'uses useT as const': {
           string: 'uses useT as const',
           meta: { context: [], tags: [], occurrences: ['react.jsx'] },
         },
-        '14a6af017c176654aaf0df13d1179418': {
+        'uses _str as const': {
           string: 'uses _str as const',
           meta: { context: [], tags: [], occurrences: ['react.jsx'] },
         },
-        '6f48100ca5a57d2db9b685a8373be8a6': {
+        'Text 1::foo': {
           string: 'Text 1',
           meta: {
             character_limit: 10,
@@ -113,35 +115,35 @@ describe('extractPhrases', () => {
             occurrences: ['react.jsx'],
           },
         },
-        '5d47152bcd597dd6adbff4884374aaad': {
+        'Text 2': {
           string: 'Text 2',
           meta: { context: [], tags: [], occurrences: ['react.jsx'] },
         },
-        '3cd62915590816fdbf53852e44ee675a': {
+        'Text 3': {
           string: 'Text 3',
           meta: { context: [], tags: [], occurrences: ['react.jsx'] },
         },
-        '33f5afa925f1464280d72d6d9086057c': {
+        'Text 4': {
           string: 'Text 4',
           meta: { context: [], tags: [], occurrences: ['react.jsx'] },
         },
-        '90da95711d6dc69953b2978d2bed9b7d': {
+        'A {button} and a {bold} walk into a bar': {
           string: 'A {button} and a {bold} walk into a bar',
           meta: { context: [], tags: [], occurrences: ['react.jsx'] },
         },
-        a667d8741bde4f79971b6220a0c0b647: {
+        button: {
           string: 'button',
           meta: { context: [], tags: [], occurrences: ['react.jsx'] },
         },
-        e5f9dda0c39f13357321d0c07bb7a3ff: {
+        bold: {
           string: 'bold',
           meta: { context: [], tags: [], occurrences: ['react.jsx'] },
         },
-        '16c514ade457a04f8a5e074fe705fd09': {
+        '<b>HTML text</b>': {
           string: '<b>HTML text</b>',
           meta: { context: [], tags: ['tag1'], occurrences: ['react.jsx'] },
         },
-        ff6354c17646535001825818343d64f3: {
+        '<b>HTML inline text</b>': {
           string: '<b>HTML inline text</b>',
           meta: { context: [], tags: [], occurrences: ['react.jsx'] },
         },
@@ -151,7 +153,7 @@ describe('extractPhrases', () => {
   it('works with tsx', async () => {
     expect(await extractPhrases('test/fixtures/react.tsx', 'react.tsx'))
       .to.deep.equal({
-        '6f48100ca5a57d2db9b685a8373be8a6': {
+        'Text 1::foo': {
           string: 'Text 1',
           meta: {
             character_limit: 10,
@@ -161,35 +163,35 @@ describe('extractPhrases', () => {
             occurrences: ['react.tsx'],
           },
         },
-        '5d47152bcd597dd6adbff4884374aaad': {
+        'Text 2': {
           string: 'Text 2',
           meta: { context: [], tags: [], occurrences: ['react.tsx'] },
         },
-        '3cd62915590816fdbf53852e44ee675a': {
+        'Text 3': {
           string: 'Text 3',
           meta: { context: [], tags: [], occurrences: ['react.tsx'] },
         },
-        '33f5afa925f1464280d72d6d9086057c': {
+        'Text 4': {
           string: 'Text 4',
           meta: { context: [], tags: [], occurrences: ['react.tsx'] },
         },
-        '90da95711d6dc69953b2978d2bed9b7d': {
+        'A {button} and a {bold} walk into a bar': {
           string: 'A {button} and a {bold} walk into a bar',
           meta: { context: [], tags: [], occurrences: ['react.tsx'] },
         },
-        a667d8741bde4f79971b6220a0c0b647: {
+        button: {
           string: 'button',
           meta: { context: [], tags: [], occurrences: ['react.tsx'] },
         },
-        e5f9dda0c39f13357321d0c07bb7a3ff: {
+        bold: {
           string: 'bold',
           meta: { context: [], tags: [], occurrences: ['react.tsx'] },
         },
-        '16c514ade457a04f8a5e074fe705fd09': {
+        '<b>HTML text</b>': {
           string: '<b>HTML text</b>',
           meta: { context: [], tags: ['tag1'], occurrences: ['react.tsx'] },
         },
-        ff6354c17646535001825818343d64f3: {
+        '<b>HTML inline text</b>': {
           string: '<b>HTML inline text</b>',
           meta: { context: [], tags: [], occurrences: ['react.tsx'] },
         },
@@ -203,7 +205,7 @@ describe('extractPhrases', () => {
           string: 'Monday',
           meta: { context: [], tags: [], occurrences: ['typescript.ts'] },
         },
-        d3b72592c4af5b55aac2dd0c88a9422a: {
+        Shoes: {
           string: 'Shoes',
           meta: { context: [], tags: [], occurrences: ['typescript.ts'] },
         },
@@ -213,19 +215,19 @@ describe('extractPhrases', () => {
   it('works with decorators', async () => {
     expect(await extractPhrases('test/fixtures/decorators.js', 'decorators.js'))
       .to.deep.equal({
-        bc077c881a53b3575ffe7eaf390ffca4: {
+        'Component with decorator': {
           string: 'Component with decorator',
           meta: { context: [], tags: [], occurrences: ['decorators.js'] },
         },
-        d1695cddb12ea34290ad14c90bc88a39: {
+        'TestClass1 example': {
           string: 'TestClass1 example',
           meta: { context: [], tags: [], occurrences: ['decorators.js'] },
         },
-        cf24b3ddbdaaa21f7aba79187ef01f63: {
+        'TestClass2 example': {
           string: 'TestClass2 example',
           meta: { context: [], tags: [], occurrences: ['decorators.js'] },
         },
-        d18654e576453293d60dbb2833b914f3: {
+        'TestClass3 example': {
           string: 'TestClass3 example',
           meta: { context: [], tags: [], occurrences: ['decorators.js'] },
         },
@@ -235,15 +237,15 @@ describe('extractPhrases', () => {
   it('works with class properties', async () => {
     expect(await extractPhrases('test/fixtures/classproperties.js', 'classproperties.js'))
       .to.deep.equal({
-        '4f8d30aecb6784371423169bd67067f4': {
+        'Static Property text': {
           string: 'Static Property text',
           meta: { context: [], tags: [], occurrences: ['classproperties.js'] },
         },
-        '6eb781ad9f94e72e7e3e1eb8d84e9b23': {
+        'Instance property text': {
           string: 'Instance property text',
           meta: { context: [], tags: [], occurrences: ['classproperties.js'] },
         },
-        a5341bc1ed5a4c2278f50fa60cd359c9: {
+        'Static Function text': {
           string: 'Static Function text',
           meta: { context: [], tags: [], occurrences: ['classproperties.js'] },
         },
@@ -253,31 +255,31 @@ describe('extractPhrases', () => {
   it('works with const identifiers', async () => {
     expect(await extractPhrases('test/fixtures/variables.js', 'variables.js'))
       .to.deep.equal({
-        '5d34b0b02c893763b0679f0aeab472ae': {
+        abc: {
           string: 'abc',
           meta: { context: [], tags: [], occurrences: ['variables.js'] },
         },
-        '06af01ed1976798d82a569a6e0af7537': {
+        'Outer Text': {
           string: 'Outer Text',
           meta: { context: [], tags: [], occurrences: ['variables.js'] },
         },
-        f089f645d1baa0ce4f398a4388520de3: {
+        ' Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text': {
           string: ' Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text',
           meta: { context: [], tags: [], occurrences: ['variables.js'] },
         },
-        ac186ba33ab07d1ba8864f15662c308c: {
+        'Outer Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text': {
           string: 'Outer Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text',
           meta: { context: [], tags: [], occurrences: ['variables.js'] },
         },
-        e5609fd3ccf5a0e9eea07d2a0918c2bd: {
+        abcdefg: {
           string: 'abcdefg',
           meta: { context: [], tags: [], occurrences: ['variables.js'] },
         },
-        '3a2a11e5b86fdb8e2807170eca54171f': {
+        'Inner Text': {
           string: 'Inner Text',
           meta: { context: [], tags: [], occurrences: ['variables.js'] },
         },
-        '7c023dc6beb7e942ab667c8d32a488e7': {
+        'Inner Text,Outer Text': {
           string: 'Inner Text,Outer Text',
           meta: { context: [], tags: [], occurrences: ['variables.js'] },
         },
@@ -303,11 +305,11 @@ describe('extractPhrases', () => {
           string: 'This is a pipe text',
           meta: { context: [], tags: [], occurrences: ['angular-template.html'] },
         },
-        def7319eabb4be374d5fae8ea5b79d55: {
+        'This is a second pipe text': {
           string: 'This is a second pipe text',
           meta: { context: [], tags: [], occurrences: ['angular-template.html'] },
         },
-        '9eae72bb80f1d30adc39a97c56eb2f6b': {
+        '\n      This is a\n      third pipe text\n      ': {
           string: '\n      This is a\n      third pipe text\n      ',
           meta: { context: [], tags: [], occurrences: ['angular-template.html'] },
         },
@@ -323,17 +325,13 @@ describe('extractPhrases', () => {
           string: 'This is a sixth pipe text, no one should do this',
           meta: { context: [], tags: [], occurrences: ['angular-template.html'] },
         },
-        '867b7cc4643da9b4c97ababa43c50c23': {
+        'Used in a {binding}': {
           string: 'Used in a {binding}',
           meta: { context: [], tags: [], occurrences: ['angular-template.html'] },
         },
         'text.pipe_binding': {
           string: 'Used in a second binding',
           meta: { context: [], tags: [], occurrences: ['angular-template.html'] },
-        },
-        'content.is-text': {
-          string: 'This is a text with a context, and it should be recognized as one',
-          meta: { context: ['is-text'], tags: [], occurrences: ['angular-template.html'] },
         },
         'content.is-text': {
           string: 'This is a text with a context, and it should be recognized as one',

--- a/packages/cli/test/commands/push.test.js
+++ b/packages/cli/test/commands/push.test.js
@@ -12,7 +12,7 @@ describe('push command', () => {
 
   test
     .stdout()
-    .command(['push', 'test/fixtures/simple.js', '--dry-run', '-v'])
+    .command(['push', 'test/fixtures/simple.js', '--dry-run', '-v', '--key-generator=hash'])
     .it('outputs strings on verbose mode', (ctx) => {
       expect(ctx.stdout).to.contain('f2138b2131e064313c369b20006549df: Text 1');
       expect(ctx.stdout).to.contain('5d47152bcd597dd6adbff4884374aaad: Text 2');
@@ -23,7 +23,32 @@ describe('push command', () => {
 
   test
     .stdout()
+    .command(['push', 'test/fixtures/simple.js', '--dry-run', '-v'])
+    .it('outputs strings on verbose mode', (ctx) => {
+      expect(ctx.stdout).to.contain('Text 1: Text 1');
+      expect(ctx.stdout).to.contain('Text 2: Text 2');
+      expect(ctx.stdout).to.contain('Text 3: Text 3');
+      expect(ctx.stdout).to.contain('Text 4: Text 4');
+      expect(ctx.stdout).to.contain('occurrences: ["/test/fixtures/simple.js"]');
+    });
+
+  test
+    .stdout()
+    .command(['push', 'test/fixtures/', '--dry-run', '-v', '--key-generator=hash'])
+    .it('outputs strings on verbose mode', (ctx) => {
+      expect(ctx.stdout).to.contain('f2138b2131e064313c369b20006549df: Text 1');
+    });
+
+  test
+    .stdout()
     .command(['push', 'test/fixtures/', '--dry-run', '-v'])
+    .it('outputs strings on verbose mode', (ctx) => {
+      expect(ctx.stdout).to.contain('Text 1: Text 1');
+    });
+
+  test
+    .stdout()
+    .command(['push', 'test/fixtures/*.js', '--dry-run', '-v', '--key-generator=hash'])
     .it('outputs strings on verbose mode', (ctx) => {
       expect(ctx.stdout).to.contain('f2138b2131e064313c369b20006549df: Text 1');
     });
@@ -32,14 +57,21 @@ describe('push command', () => {
     .stdout()
     .command(['push', 'test/fixtures/*.js', '--dry-run', '-v'])
     .it('outputs strings on verbose mode', (ctx) => {
-      expect(ctx.stdout).to.contain('f2138b2131e064313c369b20006549df: Text 1');
+      expect(ctx.stdout).to.contain('Text 1: Text 1');
+    });
+
+  test
+    .stdout()
+    .command(['push', 'test/fixtures/*.foo', '--dry-run', '-v', '--key-generator=hash'])
+    .it('outputs strings on verbose mode', (ctx) => {
+      expect(ctx.stdout).to.not.contain('f2138b2131e064313c369b20006549df: Text 1');
     });
 
   test
     .stdout()
     .command(['push', 'test/fixtures/*.foo', '--dry-run', '-v'])
     .it('outputs strings on verbose mode', (ctx) => {
-      expect(ctx.stdout).to.not.contain('f2138b2131e064313c369b20006549df: Text 1');
+      expect(ctx.stdout).to.not.contain('Text 1: Text 1');
     });
 
   test

--- a/packages/native/src/utils.js
+++ b/packages/native/src/utils.js
@@ -11,6 +11,25 @@ import md5 from 'md5';
 export function generateKey(string, options = {}) {
   if (options._key) return options._key;
 
+  if (options._context) {
+    return `${string}::${options._context}`;
+  }
+
+  // ensure string is returned
+  return `${string}`;
+}
+
+/**
+ * Generate a hashed based string key
+ *
+ * @export
+ * @param {String} string
+ * @param {Object} options
+ * @returns {String} key
+ */
+export function generateHashedKey(string, options = {}) {
+  if (options._key) return options._key;
+
   let context = '';
   if (options._context) {
     context = options._context;

--- a/packages/native/tests/utils.test.js
+++ b/packages/native/tests/utils.test.js
@@ -4,6 +4,7 @@ import { expect } from 'chai';
 import {
   escape, generateKey, isString, normalizeLocale, isPluralized,
 } from '../src/index';
+import { generateHashedKey } from '../src/utils';
 
 describe('Util functions', () => {
   it('escape', () => {
@@ -12,24 +13,46 @@ describe('Util functions', () => {
 
   it('generateKey', () => {
     expect(generateKey('foo'))
-      .to.equal('2028d52912f9f7df555c9b5b7e886477');
+      .to.equal('foo');
     expect(generateKey('Hello {username}'))
-      .to.equal('52f77f95a06daa76876c5cf97c04ac39');
+      .to.equal('Hello {username}');
     expect(generateKey('Γειά σου {username}'))
-      .to.equal('496bd9f3c08c431bca41a73fc9d333f8');
+      .to.equal('Γειά σου {username}');
     expect(generateKey('I have {n, plural, one {# apple} other {# apples}}'))
-      .to.equal('21a07a689ffa510ed943839d7f4c7a52');
+      .to.equal('I have {n, plural, one {# apple} other {# apples}}');
 
     // with context
     expect(generateKey('This is a nice phrase', {
       _context: 'some context',
-    })).to.equal('1cef92f8501667684496766587608795');
+    })).to.equal('This is a nice phrase::some context');
     expect(generateKey('This is a nice phrase', {
+      _context: 'context1,context2,context2',
+    })).to.equal('This is a nice phrase::context1,context2,context2');
+
+    // overrides key
+    expect(generateKey('foo', { _key: 'bar' })).to.equal('bar');
+  });
+
+  it('generateHashedKey', () => {
+    expect(generateHashedKey('foo'))
+      .to.equal('2028d52912f9f7df555c9b5b7e886477');
+    expect(generateHashedKey('Hello {username}'))
+      .to.equal('52f77f95a06daa76876c5cf97c04ac39');
+    expect(generateHashedKey('Γειά σου {username}'))
+      .to.equal('496bd9f3c08c431bca41a73fc9d333f8');
+    expect(generateHashedKey('I have {n, plural, one {# apple} other {# apples}}'))
+      .to.equal('21a07a689ffa510ed943839d7f4c7a52');
+
+    // with context
+    expect(generateHashedKey('This is a nice phrase', {
+      _context: 'some context',
+    })).to.equal('1cef92f8501667684496766587608795');
+    expect(generateHashedKey('This is a nice phrase', {
       _context: 'context1,context2,context2',
     })).to.equal('ba7e05eb67b7854841bef07de562e618');
 
     // overrides key
-    expect(generateKey('foo', { _key: 'bar' })).to.equal('bar');
+    expect(generateHashedKey('foo', { _key: 'bar' })).to.equal('bar');
   });
 
   it('isString', () => {


### PR DESCRIPTION
Add support for source based keys instead of hash based ones. 

Changes:
- @transifex/native will search for source based keys and fallback to hash based keys during translation discovery.
- @transifex/cli will push using source based keys by default, unless explicitly set to hash based keys using the `--key-generator=hash` flag.