### PR TITLE
Remove "module" definition from package.json

### DIFF
--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -13,7 +13,6 @@
   "license": "Apache-2.0",
   "main": "dist/node.native.js",
   "browser": "dist/browser.native.js",
-  "module": "src/index.js",
   "types": "dist/node.native.d.ts",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Using "module" field in package.json of @transifex/native is causing issues because the code is using 2 constants set by Webpack DefinePlugin. 

This creates compilation problems in Webpack configurations that are using tree-shaking with Native libraries.
