### PR TITLE
Add Messageformat date/time localization support

### DIFF
--- a/packages/cli/src/commands/push.js
+++ b/packages/cli/src/commands/push.js
@@ -108,7 +108,11 @@ class PushCommand extends Command {
         if (_.isEmpty(data)) return;
         this.log(file.green);
         _.each(data, (value, key) => {
-          this.log(`  └─ ${key}: ${value.string.underline}`);
+          if (key !== value.string) {
+            this.log(`  └─ ${key}: ${value.string.underline}`);
+          } else {
+            this.log(`  └─ ${value.string.underline}`);
+          }
           _.each(value.meta, (meta, metaKey) => {
             if ((_.isObject(meta) || _.isArray(meta)) && _.isEmpty(meta)) {
               return;

--- a/packages/cli/test/commands/push.test.js
+++ b/packages/cli/test/commands/push.test.js
@@ -25,10 +25,10 @@ describe('push command', () => {
     .stdout()
     .command(['push', 'test/fixtures/simple.js', '--dry-run', '-v'])
     .it('outputs strings on verbose mode', (ctx) => {
-      expect(ctx.stdout).to.contain('Text 1: Text 1');
-      expect(ctx.stdout).to.contain('Text 2: Text 2');
-      expect(ctx.stdout).to.contain('Text 3: Text 3');
-      expect(ctx.stdout).to.contain('Text 4: Text 4');
+      expect(ctx.stdout).to.contain('Text 1');
+      expect(ctx.stdout).to.contain('Text 2');
+      expect(ctx.stdout).to.contain('Text 3');
+      expect(ctx.stdout).to.contain('Text 4');
       expect(ctx.stdout).to.contain('occurrences: ["/test/fixtures/simple.js"]');
     });
 
@@ -43,7 +43,7 @@ describe('push command', () => {
     .stdout()
     .command(['push', 'test/fixtures/', '--dry-run', '-v'])
     .it('outputs strings on verbose mode', (ctx) => {
-      expect(ctx.stdout).to.contain('Text 1: Text 1');
+      expect(ctx.stdout).to.contain('Text 1');
     });
 
   test
@@ -57,7 +57,7 @@ describe('push command', () => {
     .stdout()
     .command(['push', 'test/fixtures/*.js', '--dry-run', '-v'])
     .it('outputs strings on verbose mode', (ctx) => {
-      expect(ctx.stdout).to.contain('Text 1: Text 1');
+      expect(ctx.stdout).to.contain('Text 1');
     });
 
   test
@@ -71,7 +71,7 @@ describe('push command', () => {
     .stdout()
     .command(['push', 'test/fixtures/*.foo', '--dry-run', '-v'])
     .it('outputs strings on verbose mode', (ctx) => {
-      expect(ctx.stdout).to.not.contain('Text 1: Text 1');
+      expect(ctx.stdout).to.not.contain('Text 1');
     });
 
   test

--- a/packages/native/src/renderers/MessageFormatRenderer.js
+++ b/packages/native/src/renderers/MessageFormatRenderer.js
@@ -1,7 +1,9 @@
 /* eslint-disable class-methods-use-this */
 import MessageFormat from '@messageformat/core';
 
-const MF = new MessageFormat();
+// object to cache MessageFormat classes related to
+// specific locales
+const MF = {};
 
 /**
  * MessageFormat renderer
@@ -11,7 +13,17 @@ const MF = new MessageFormat();
  */
 export default class MessageFormatRenderer {
   render(sourceString, localeCode, params) {
-    const msg = MF.compile(sourceString);
+    // construct a MessageFormat class based on locale
+    // to make dates and other content localizable
+    const locale = ((localeCode || '').split('_'))[0];
+    if (!MF[locale]) {
+      try {
+        MF[locale] = new MessageFormat(locale);
+      } catch (err) {
+        MF[locale] = new MessageFormat();
+      }
+    }
+    const msg = MF[locale].compile(sourceString);
     return msg(params);
   }
 }

--- a/packages/native/tests/renderer.test.js
+++ b/packages/native/tests/renderer.test.js
@@ -3,6 +3,8 @@
 import { expect } from 'chai';
 import { tx, t } from '../src/index';
 
+const NODE_VER = parseInt((process.version.split('.')[0]).replace('v', ''), 10);
+
 describe('String renderer', () => {
   it('renders with localized dates', async () => {
     const d = Date.parse('2020-02-01');
@@ -11,13 +13,18 @@ describe('String renderer', () => {
     expect(tx.stringRenderer.render('Date is {d, date, long}', '', { d }))
       .to.equal('Date is February 1, 2020');
 
-    // French locale
-    expect(tx.stringRenderer.render('Date is {d, date, long}', 'fr', { d }))
-      .to.equal('Date is 1 février 2020');
+    // Node prior to 13 is build with small-icu support and date localization
+    // will not work. So enable this test only on latest versions
+    expect(NODE_VER).to.be.greaterThanOrEqual(10);
+    if (NODE_VER >= 13) {
+      // French locale
+      expect(tx.stringRenderer.render('Date is {d, date, long}', 'fr', { d }))
+        .to.equal('Date is 1 février 2020');
 
-    // German locale
-    expect(tx.stringRenderer.render('Date is {d, date, long}', 'de_DE', { d }))
-      .to.equal('Date is 1. Februar 2020');
+      // German locale
+      expect(tx.stringRenderer.render('Date is {d, date, long}', 'de_DE', { d }))
+        .to.equal('Date is 1. Februar 2020');
+    }
 
     // invalid locale fallsback to english
     expect(tx.stringRenderer.render('Date is {d, date, long}', 'a', { d }))

--- a/packages/native/tests/renderer.test.js
+++ b/packages/native/tests/renderer.test.js
@@ -4,6 +4,26 @@ import { expect } from 'chai';
 import { tx, t } from '../src/index';
 
 describe('String renderer', () => {
+  it('renders with localized dates', async () => {
+    const d = Date.parse('2020-02-01');
+
+    // default locale
+    expect(tx.stringRenderer.render('Date is {d, date, long}', '', { d }))
+      .to.equal('Date is February 1, 2020');
+
+    // French locale
+    expect(tx.stringRenderer.render('Date is {d, date, long}', 'fr', { d }))
+      .to.equal('Date is 1 février 2020');
+
+    // German locale
+    expect(tx.stringRenderer.render('Date is {d, date, long}', 'de_DE', { d }))
+      .to.equal('Date is 1. Februar 2020');
+
+    // invalid locale fallsback to english
+    expect(tx.stringRenderer.render('Date is {d, date, long}', 'a', { d }))
+      .to.equal('Date is February 1, 2020');
+  });
+
   it('renders with custom renderer', async () => {
     const oldRenderer = tx.stringRenderer;
 


### PR DESCRIPTION
**@transifex/native**
We were using a single MessageFormat class instance for the entire runtime, defaulting to English locale. This has an issue when trying to use an ICU phrase with dates, e.g. `Date is {d, date, long}`.

This PR fixes the issue by creating a MessageFormat instance per locale. Now, dates are properly localized internally by the MessageFormat library.

**@transifex/cli**
Minor improvement to avoid showing the key when it is the same as source in verbose mode `txjs-cli push -v`
