### PR TITLE
Add ability to use multiple TX Native instances

### DIFF
--- a/packages/native/README.md
+++ b/packages/native/README.md
@@ -266,6 +266,35 @@ offEvent(type, function)
 sendEvent(type, payload, caller)
 ```
 
+## Using more than one TX Native instances
+
+```js
+const { tx, t, createNativeInstance } = require('@transifex/native');
+
+// Initiatate a secondary TX Instance
+const txOtherInstance = createNativeInstance();
+txOtherInstance.init({
+  token: '<PUBLIC PROJECT TOKEN 2>',
+})
+
+// initialize SDK
+tx.init({
+  token: '<PUBLIC PROJECT TOKEN>',
+});
+
+// Use tx as a controller of the other instance
+tx.controllerOf(txOtherInstance);
+
+// get all languages
+tx.setCurrentLocale('fr').then(function() {
+  // translate something
+  const message = t('Welcome {user}', {user: 'Joe'});
+  console.log(message);
+  const message2 = txOtherInstance.t('Welcome {user}', {user: 'Joe'});
+  console.log(message2);
+});
+```
+
 # License
 
 Licensed under Apache License 2.0, see [LICENSE](https://github.com/transifex/transifex-javascript/blob/HEAD/LICENSE) file.

--- a/packages/native/src/index.d.ts
+++ b/packages/native/src/index.d.ts
@@ -6,4 +6,5 @@ declare module '@transifex/native' {
   export const SourceErrorPolicy: any;
   export const ThrowErrorPolicy: any;
   export const MessageFormatRenderer: any;
+  export const createNativeInstance: any;
 }

--- a/packages/native/src/index.js
+++ b/packages/native/src/index.js
@@ -7,6 +7,15 @@ import _SourceErrorPolicy from './policies/SourceErrorPolicy';
 import _ThrowErrorPolicy from './policies/ThrowErrorPolicy';
 import _MessageFormatRenderer from './renderers/MessageFormatRenderer';
 
+function _createNativeInstance(initOptions) {
+  const instance = new TxNative();
+  instance.t = instance.translate.bind(instance);
+  if (initOptions) {
+    instance.init(initOptions);
+  }
+  return instance;
+}
+
 export * from './utils';
 export * from './events';
 
@@ -15,6 +24,7 @@ export const SourceStringPolicy = _SourceStringPolicy;
 export const SourceErrorPolicy = _SourceErrorPolicy;
 export const ThrowErrorPolicy = _ThrowErrorPolicy;
 export const MessageFormatRenderer = _MessageFormatRenderer;
+export const createNativeInstance = _createNativeInstance;
 
 export const tx = new TxNative();
 export const t = tx.translate.bind(tx);

--- a/packages/native/tests/instance.test.js
+++ b/packages/native/tests/instance.test.js
@@ -1,0 +1,77 @@
+/* globals describe, it */
+
+import { expect } from 'chai';
+import { createNativeInstance } from '../src/index';
+
+describe('Native instance', () => {
+  it('updates child locale', async () => {
+    const controller = createNativeInstance();
+    const child = createNativeInstance();
+
+    controller.cache.update('el', {});
+
+    await controller.controllerOf(child);
+    await controller.setCurrentLocale('el');
+
+    expect(controller.getCurrentLocale()).to.equal('el');
+    expect(child.getCurrentLocale()).to.equal('el');
+  });
+
+  it('updates child locale lazy', async () => {
+    const controller = createNativeInstance();
+    const child = createNativeInstance();
+
+    controller.cache.update('el', {});
+
+    await controller.setCurrentLocale('el');
+
+    expect(controller.getCurrentLocale()).to.equal('el');
+    expect(child.getCurrentLocale()).to.equal('');
+
+    await controller.controllerOf(child);
+
+    expect(child.getCurrentLocale()).to.equal('el');
+  });
+
+  it('updates child locale when not set', async () => {
+    const controller = createNativeInstance();
+    const child = createNativeInstance();
+
+    controller.cache.update('el', {});
+    child.cache.update('el', {});
+
+    await controller.setCurrentLocale('el');
+    await child.setCurrentLocale('el');
+
+    expect(controller.getCurrentLocale()).to.equal('el');
+    expect(child.getCurrentLocale()).to.equal('el');
+
+    await controller.controllerOf(child);
+    await controller.setCurrentLocale();
+
+    expect(controller.getCurrentLocale()).to.equal('');
+    expect(child.getCurrentLocale()).to.equal('');
+  });
+
+  it('throws when child reference is invalid', async () => {
+    const controller = createNativeInstance();
+    const child = createNativeInstance();
+
+    let throws = false;
+    try {
+      await controller.controllerOf(controller);
+    } catch (e) {
+      throws = true;
+    }
+    expect(throws).to.equal(true);
+
+    throws = false;
+    await controller.controllerOf(child);
+    try {
+      await child.controllerOf(controller);
+    } catch (e) {
+      throws = true;
+    }
+    expect(throws).to.equal(true);
+  });
+});

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -175,6 +175,24 @@ function DisplayLocale () {
 }
 ```
 
+## `useTX` hook
+
+Returns a state variable with the Native instance.
+
+```jsx
+import React from 'react';
+import { useTX } from '@transifex/react';
+
+function SetLocale () {
+  const tx = useTX();
+  return (
+    <button onClick={() => tx.setCurrentLocale('el')}>
+      Set to Greek
+    </button>
+  );
+}
+```
+
 ## `LanguagePicker` component
 
 Renders a `<select>` tag that displays supported languages and switches the
@@ -287,6 +305,37 @@ function Inner({ ready }) {
   return <T
     _str="This will be translated when the inner component is rendered"
     _tags="inner" />;
+}
+```
+
+## `TXProvider` provider
+If you need to use more than one Transifex Native instances - like for example if you have a component library - you can use this provider to pass the desired instance to the children components.
+
+```js
+import { tx, createNativeInstance } from '@transifex/native';
+import { TXProvider, LanguagePicker, T } from '@transifex/react';
+
+const myOtherTXInstance = createNativeInstance();
+myOtherTXInstance.init({ token: 'othertoken' })
+
+tx.init({
+  token: 'token',
+});
+
+// Make tx aware of the other instances so they can be synced when changing
+// language
+tx.controllerOf(myOtherTXInstance);
+
+export default function App() {
+  return (
+    <>
+      <LanguagePicker />
+      <TXProvider instance={myOtherTXInstance}>
+        <T _str="Hello {username}" username="John" />
+      </TXProvider>
+      <T _str="Hello World" />
+    </>
+  );
 }
 ```
 

--- a/packages/react/src/components/LanguagePicker.jsx
+++ b/packages/react/src/components/LanguagePicker.jsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { tx } from '@transifex/native';
-
 import useLanguages from '../hooks/useLanguages';
 import useLocale from '../hooks/useLocale';
+import useTX from '../hooks/useTX';
 
 /* Component to render a language picker. Language options will be fetched
   * asynchronously. Accepts props:
@@ -14,6 +13,7 @@ import useLocale from '../hooks/useLocale';
 export default function LanguagePicker({ className }) {
   const languages = useLanguages();
   const locale = useLocale();
+  const tx = useTX();
 
   return (
     <select

--- a/packages/react/src/components/TXProvider.jsx
+++ b/packages/react/src/components/TXProvider.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { TXNativeContext } from '../context/TXNativeContext';
+
+export default function TXProvider({ instance, children }) {
+  return (
+    <TXNativeContext.Provider value={{instance}}>
+      {children}
+    </TXNativeContext.Provider>
+  );
+}

--- a/packages/react/src/context/TXNativeContext.jsx
+++ b/packages/react/src/context/TXNativeContext.jsx
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+
+export const TXNativeContext = createContext({
+  instance: null,
+});

--- a/packages/react/src/hooks/useLanguages.js
+++ b/packages/react/src/hooks/useLanguages.js
@@ -1,5 +1,6 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useContext } from 'react';
 import { tx } from '@transifex/native';
+import { TXNativeContext } from '../context/TXNativeContext';
 
 /* Return a state variable that will soon be populated with the available
  * languages
@@ -19,12 +20,16 @@ import { tx } from '@transifex/native';
  * } */
 
 export default function useLanguages() {
+  // Check for a different tx initialization
+  const context = useContext(TXNativeContext);
+  const instance = context.instance || tx;
+
   const [languages, setLanguages] = useState([]);
   useEffect(() => {
     async function fetch() {
-      setLanguages(await tx.getLanguages());
+      setLanguages(await instance.getLanguages());
     }
     fetch();
-  }, []);
+  }, [instance]);
   return languages;
 }

--- a/packages/react/src/hooks/useLocale.js
+++ b/packages/react/src/hooks/useLocale.js
@@ -1,7 +1,8 @@
-import { useEffect, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import {
   tx, onEvent, offEvent, LOCALE_CHANGED,
 } from '@transifex/native';
+import { TXNativeContext } from '../context/TXNativeContext';
 
 /* Return a state variable with the currently selected locale, e.g. 'en'
  *
@@ -18,20 +19,25 @@ import {
  *   );
  * }
  */
-
 export default function useLocale() {
-  const [locale, setLocale] = useState(tx.getCurrentLocale());
+  // Check for a different tx initialization
+  const context = useContext(TXNativeContext);
+  const instance = context.instance || tx;
+
+  const [locale, setLocale] = useState(instance.getCurrentLocale());
 
   useEffect(() => {
-    function cb() {
-      setLocale(tx.getCurrentLocale());
+    function cb(_, caller) {
+      if (caller === instance) {
+        setLocale(instance.getCurrentLocale());
+      }
     }
 
     onEvent(LOCALE_CHANGED, cb);
     return () => {
       offEvent(LOCALE_CHANGED, cb);
     };
-  }, []);
+  }, [instance]);
 
   return locale;
 }

--- a/packages/react/src/hooks/useTX.js
+++ b/packages/react/src/hooks/useTX.js
@@ -1,0 +1,24 @@
+import { useContext } from 'react';
+import { tx } from '@transifex/native';
+import { TXNativeContext } from '../context/TXNativeContext';
+
+/* Return a state variable with the currently selected TX Native instance.
+ *
+ * Usage:
+ *
+ * function LanguagePicker() {
+ *   const tx = useTX();
+ *   function handle() {
+ *     tx.setCurrentLanguage('fr');
+ *   }
+ *
+ *   return (
+ *      ...
+ *   );
+ * }
+ */
+export default function useTX() {
+  // Check for a different tx initialization
+  const context = useContext(TXNativeContext);
+  return context.instance || tx;
+}

--- a/packages/react/src/index.d.ts
+++ b/packages/react/src/index.d.ts
@@ -6,3 +6,4 @@ export const UT : TransifexReact.UT;
 export const useLanguages : TransifexReact.useLanguages;
 export const useLocale : TransifexReact.useLocale;
 export const useT : TransifexReact.useT;
+export const TXProvider : TransifexReact.TXProvider;

--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -3,7 +3,9 @@
 export { default as useLanguages } from './hooks/useLanguages';
 export { default as useLocale } from './hooks/useLocale';
 export { default as useT } from './hooks/useT';
+export { default as useTX } from './hooks/useTX';
 export { default as useTranslations } from './hooks/useTranslations';
 export { default as LanguagePicker } from './components/LanguagePicker';
 export { default as T } from './components/T';
 export { default as UT } from './components/UT';
+export { default as TXProvider } from './components/TXProvider';

--- a/packages/react/src/utils/translateWithElements.jsx
+++ b/packages/react/src/utils/translateWithElements.jsx
@@ -1,5 +1,5 @@
+/* eslint-disable no-underscore-dangle */
 import React, { Fragment } from 'react';
-
 import { t } from '@transifex/native';
 
 /*  Wrapper of `t`-function that can accept React elements as properties. This
@@ -14,7 +14,13 @@ import { t } from '@transifex/native';
   * an array of React elements, each within its unique `key` property and, if
   * there are more than one, will be returned as `<>{result}</>`. */
 
-function translateWithElements(_str, props) {
+function translateWithElements(_str, props, context) {
+  let _t = t;
+  if (context && context.instance) {
+    const _tx = context.instance;
+    _t = _tx.t;
+  }
+
   const actualProps = {};
   const reactElements = [];
   if (props) {
@@ -27,7 +33,7 @@ function translateWithElements(_str, props) {
       }
     });
   }
-  const translation = t(_str, actualProps);
+  const translation = _t(_str, actualProps);
   const result = [];
   let lastEnd = 0;
   let lastKey = 0;

--- a/packages/react/tests/useLanguages.test.js
+++ b/packages/react/tests/useLanguages.test.js
@@ -6,8 +6,8 @@ import {
   render, screen, cleanup, waitFor,
 } from '@testing-library/react';
 
-import { tx } from '@transifex/native';
-import { useLanguages } from '../src';
+import { tx, createNativeInstance } from '@transifex/native';
+import { useLanguages, TXProvider } from '../src';
 
 let oldGetLanguages;
 beforeEach(() => {
@@ -39,4 +39,30 @@ test('fetches languages', async () => {
   await waitFor(() => screen.getByText('el: Greek'));
   expect(screen.queryByText('el: Greek')).toBeTruthy();
   expect(screen.queryByText('fr: French')).toBeTruthy();
+});
+
+test('fetches languages on provider', async () => {
+  function LanguageList() {
+    const languages = useLanguages();
+    return (
+      <>
+        {languages.map(({ code, name }) => {
+          const text = `${code}: ${name}`;
+          return <p key={code}>{text}</p>;
+        })}
+      </>
+    );
+  }
+  const instance = createNativeInstance();
+  instance.getLanguages = async () => [
+    { code: 'foo', name: 'Bar' },
+  ];
+
+  render(
+    <TXProvider instance={instance}>
+      <LanguageList />
+    </TXProvider>,
+  );
+  await waitFor(() => screen.getByText('foo: Bar'));
+  expect(screen.queryByText('foo: Bar')).toBeTruthy();
 });

--- a/packages/react/tests/useTX.test.js
+++ b/packages/react/tests/useTX.test.js
@@ -1,0 +1,48 @@
+/* globals expect, test */
+
+import React from 'react';
+
+import {
+  render, screen,
+} from '@testing-library/react';
+
+import { tx, createNativeInstance } from '@transifex/native';
+import { useTX, TXProvider } from '../src';
+
+test('uses default tx instance', async () => {
+  function Display() {
+    const inst = useTX();
+    return (
+      <>
+        TX Instance is {inst.name}
+      </>
+    );
+  }
+  tx.name = 'foo';
+  render(<Display />);
+  expect(screen.queryByText('TX Instance is foo')).toBeTruthy();
+  delete tx.name;
+});
+
+test('uses provider tx instance', async () => {
+  function Display() {
+    const inst = useTX();
+    return (
+      <>
+        TX Instance is {inst.name}
+      </>
+    );
+  }
+
+  const instance = createNativeInstance();
+  instance.name = 'foo';
+  tx.name = 'bar';
+
+  render(
+    <TXProvider instance={instance}>
+      <Display />
+    </TXProvider>,
+  );
+  expect(screen.queryByText('TX Instance is foo')).toBeTruthy();
+  delete tx.name;
+});


### PR DESCRIPTION
This change comes in two parts:

* TX Native library work with multiple tokens
  Since right now we exposed only the singleton tx developers couldn't
  initialize and use a second instance of Native.
  To solve this we now expose TxNative so anyone can do a

  ```js
  import { createNativeInstance } from '@transifex/native';

  const tx1 = createNativeInstance();

  tx1.init({
    token: '...'
  });
  tx1.t('a string to translate');
  ```

  To have synced state when someone changes a language in the main `tx`
  instance the developer needs to user `tx` as controller of the instance.

  ```js

  import { tx, createNativeInstance } from '@transifex/native';

  const tx1 = createNativeInstance();

  tx1.init({
   token: '...',
  });

  tx.init({
    token: '...',
  })

  tx.controllerOf(tx1);

  ```

* The React SDK part
  We created a Provider in order to help the developer use more than
  once instance if needed with the help of Context API.

  Some changes were needed in `translateWithElements` & `useT` in
  order to be aware of the context and decide which `t` function they
  will use.

  ```js
  import { tx, createNativeInstance } from '@transifex/native';
  import { LanguagePicker, TXProvider, T } from '@transifex/react';

  const tx1 = createNativeInstance();
  tx1.init({
    token: '...',
  })

  tx.init({
    token: '...',
  });

  tx.controllerOf(tx1);

  function App() {
    return (
      <div className="App">
        <LanguagePicker/>
          <TXProvider instance={tx1}>
            <T _str="Hello world" />
          </TXProvider>
        <T _str="Hello {username}" username={user} />
      </div>
    );
  }

  export default App;
  ```