### PR TITLE
Drop `colors` in favor of `@colors/colors`

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@babel/parser": "^7.13.10",
     "@babel/traverse": "^7.13.0",
+    "@colors/colors": "^1.5.0",
     "@oclif/command": "^1.8.0",
     "@oclif/config": "^1.17.0",
     "@oclif/errors": "^1.3.4",
@@ -31,7 +32,6 @@
     "angular-html-parser": "^1.7.1",
     "axios": "^0.24.0",
     "cli-ux": "^5.5.1",
-    "colors": "1.4.0",
     "ejs": "^3.1.6",
     "glob": "^7.1.6",
     "lodash": "^4.17.21",

--- a/packages/cli/src/commands/invalidate.js
+++ b/packages/cli/src/commands/invalidate.js
@@ -1,6 +1,6 @@
 /* eslint no-shadow: 0 */
 
-require('colors');
+require('@colors/colors');
 const { Command, flags } = require('@oclif/command');
 const { cli } = require('cli-ux');
 const { invalidateCDS } = require('../api/invalidate');

--- a/packages/cli/src/commands/push.js
+++ b/packages/cli/src/commands/push.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-await-in-loop */
 /* eslint no-shadow: 0 */
 
-require('colors');
+require('@colors/colors');
 const fs = require('fs');
 const path = require('path');
 const _ = require('lodash');

--- a/packages/cli/test/fixtures/variables.js
+++ b/packages/cli/test/fixtures/variables.js
@@ -22,7 +22,7 @@ function foo() {
   log(t(inner));
   log(t(`${inner},${outer}`))
 
-  const empty;
+  const empty = undefined;
   let nonConst = 'should not be visible';
   const constMadeOfNonConsts = 'again, it ' + nonConst;
   const constMadeOfTemplateLiterals = `this one is ` + nonConst;
@@ -35,4 +35,3 @@ function foo() {
 }
 
 module.exports = foo;
-


### PR DESCRIPTION
Continuation of work done in #112 

The `colors` package is no longer maintained and a weird background
story.

Previous maintainers created a new fork of the package.
https://github.com/Marak/colors.js/issues/340