### PR TITLE
Add fetch content timeout parameters

### DIFF
--- a/packages/native/README.md
+++ b/packages/native/README.md
@@ -153,6 +153,14 @@ tx.init({
 
   // Translation cache, defaults to "new MemoryCache()"
   cache: Function,
+
+  // Optional timeout in milliseconds when fetching languages and
+  // strings, defaults to 0 (no-timeout)
+  fetchTimeout: Number,
+
+  // Optional interval polling delay in milliseconds while waiting
+  // for CDS to warm-up with content, defaults to 250msec
+  fetchInterval: Number,
 })
 ```
 


### PR DESCRIPTION
When TxNative is requesting content or languages from CDS, it is gracefully handling `202` responses from CDS, instructing the SDK to retry later, because content is not ready.

But, if for any reason CDS takes too long to warm-up it's content, the SDK is stuck in an infinite loop waiting for a `200` or error response from CDS.

This PR is adding more control, so that the developer can control the behaviour of this functionality by offering two new parameters for the `tx.init(..)` function:
- `fetchTimeout`: a setting to control the time in msec, after which, the `tx.getLocales()`, `tx.setCurrentLocale()` and `tx.fetchTranslations()` will throw a timeout error.
- `fetchInterval`: a setting to add a delay (250msec by default) on the polling mechanism to CDS, to avoid doing exhaustive requests.
