### PR TITLE
Fix "glob" issue with windows paths

### DIFF
--- a/packages/angular/projects/tx-native-angular-sdk/src/lib/translation.service.ts
+++ b/packages/angular/projects/tx-native-angular-sdk/src/lib/translation.service.ts
@@ -26,6 +26,7 @@ export class TranslationService {
   }
 
   // A dictionary with additional TX Native instances for translation
+  // eslint-disable-next-line space-infix-ops
   private additionalInstances: { [id: string]: any } = {};
 
   // A subject for managing locale changes

--- a/packages/cli/src/commands/push.js
+++ b/packages/cli/src/commands/push.js
@@ -40,6 +40,7 @@ class PushCommand extends Command {
     if (isFolder(filePattern)) {
       filePattern = path.join(filePattern, PushCommand.args[0].default);
     }
+    filePattern = filePattern.replace(/\\/g, '/');
 
     const appendTags = stringToArray(flags['append-tags']);
     const filterWithTags = stringToArray(flags['with-tags-only']);


### PR DESCRIPTION
`shelljs.pwd()` returns the absolute paths with backslashes on
Windows,  while the glob package works only with forward
slashes.

The fix here was to replace backslashes with forward slashes when the
whole path was set.