### PR TITLE
@transifex/cli: Migrate to @oclif/core

### DIFF
--- a/packages/cli/bin/run
+++ b/packages/cli/bin/run
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
 
-require('@oclif/command').run()
-  .then(require('@oclif/command/flush'))
-  .catch(require('@oclif/errors/handle'));
+const oclif = require('@oclif/core');
+
+oclif.run().then(require('@oclif/core/flush')).catch(require('@oclif/core/handle'));

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,34 +24,29 @@
     "access": "public"
   },
   "dependencies": {
-    "@babel/parser": "^7.18.9",
-    "@babel/traverse": "^7.18.9",
+    "@babel/parser": "^7.20.3",
+    "@babel/traverse": "^7.20.1",
     "@colors/colors": "^1.5.0",
-    "@oclif/command": "^1.8.16",
-    "@oclif/config": "^1.18.3",
-    "@oclif/errors": "^1.3.5",
-    "@oclif/plugin-help": "^5.1.12",
+    "@oclif/core": "^1.20.4",
     "@transifex/native": "^4.3.0",
     "angular-html-parser": "^1.8.0",
-    "axios": "^0.27.2",
-    "cli-ux": "^6.0.9",
+    "axios": "^1.1.3",
     "ejs": "^3.1.8",
     "glob": "^8.0.3",
     "lodash": "^4.17.21",
     "pug": "^3.0.2",
     "shelljs": "^0.8.5",
-    "vue-template-compiler": "^2.7.7"
+    "vue-template-compiler": "^2.7.14"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.26.10",
-    "@oclif/test": "^2.1.0",
-    "chai": "^4.3.6",
-    "eslint": "^7.32.0",
-    "eslint-config-airbnb-base": "^14.2.1",
+    "@oclif/test": "^2.2.12",
+    "chai": "^4.3.7",
+    "eslint": "^8.28.0",
+    "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.26.0",
-    "globby": "^11.1.0",
-    "mocha": "^10.0.0",
-    "nock": "^13.2.8",
+    "mocha": "^10.1.0",
+    "nock": "^13.2.9",
     "nyc": "^15.1.0"
   },
   "engines": {
@@ -66,6 +61,9 @@
   "main": "src/index.js",
   "oclif": {
     "commands": "./src/commands",
+    "additionalHelpFlags": [
+      "-h"
+    ],
     "bin": "txjs-cli",
     "plugins": [
       "@oclif/plugin-help"

--- a/packages/cli/src/commands/invalidate.js
+++ b/packages/cli/src/commands/invalidate.js
@@ -1,13 +1,13 @@
 /* eslint no-shadow: 0 */
 
 require('@colors/colors');
-const { Command, flags } = require('@oclif/command');
-const { cli } = require('cli-ux');
+const { Command, Flags } = require('@oclif/core');
+const { CliUx } = require('@oclif/core');
 const { invalidateCDS } = require('../api/invalidate');
 
 class InvalidateCommand extends Command {
   async run() {
-    const { flags } = this.parse(InvalidateCommand);
+    const { flags } = await this.parse(InvalidateCommand);
 
     let cdsHost = process.env.TRANSIFEX_CDS_HOST || 'https://cds.svc.transifex.net';
     let projectToken = process.env.TRANSIFEX_TOKEN;
@@ -24,9 +24,9 @@ class InvalidateCommand extends Command {
     }
 
     if (flags.purge) {
-      cli.action.start('Invalidating and purging CDS cache', '', { stdout: true });
+      CliUx.ux.action.start('Invalidating and purging CDS cache', '', { stdout: true });
     } else {
-      cli.action.start('Invalidating CDS cache', '', { stdout: true });
+      CliUx.ux.action.start('Invalidating CDS cache', '', { stdout: true });
     }
 
     try {
@@ -36,22 +36,22 @@ class InvalidateCommand extends Command {
         secret: projectSecret,
         purge: flags.purge,
       });
-      cli.action.stop('Success'.green);
+      CliUx.ux.action.stop('Success'.green);
       this.log(`${(res.data.count || 0).toString().green} records invalidated`);
       this.log('Note: It might take a few minutes for fresh content to be available'.yellow);
     } catch (err) {
-      cli.action.stop('Failed'.red);
+      CliUx.ux.action.stop('Failed'.red);
       this.error(err);
     }
   }
 }
 
-InvalidateCommand.description = `invalidate and refresh CDS cache
+InvalidateCommand.description = `Invalidate and refresh CDS cache
 Content for delivery is cached in CDS and refreshed automatically every hour.
 This command triggers a refresh of cached content on the fly.
 
-By default, invalidation does not remove existing cached content, but
-starts the process of updating with latest translations from Transifex.
+By default, invalidation does not remove existing cached content,
+but starts the process of updating with latest translations from Transifex.
 
 Passing the --purge option, cached content will be forced to be deleted,
 however use that with caution, as it may introduce downtime of
@@ -76,19 +76,19 @@ TRANSIFEX_TOKEN=mytoken TRANSIFEX_SECRET=mysecret txjs-cli invalidate
 InvalidateCommand.args = [];
 
 InvalidateCommand.flags = {
-  purge: flags.boolean({
+  purge: Flags.boolean({
     description: 'force delete CDS cached content',
     default: false,
   }),
-  token: flags.string({
+  token: Flags.string({
     description: 'native project public token',
     default: '',
   }),
-  secret: flags.string({
+  secret: Flags.string({
     description: 'native project secret',
     default: '',
   }),
-  'cds-host': flags.string({
+  'cds-host': Flags.string({
     description: 'CDS host URL',
     default: '',
   }),

--- a/packages/cli/src/commands/push.js
+++ b/packages/cli/src/commands/push.js
@@ -5,10 +5,10 @@ require('@colors/colors');
 const fs = require('fs');
 const path = require('path');
 const _ = require('lodash');
-const { Command, flags } = require('@oclif/command');
+const { Command, Flags } = require('@oclif/core');
 const shelljs = require('shelljs');
 const { glob } = require('glob');
-const { cli } = require('cli-ux');
+const { CliUx } = require('@oclif/core');
 const { extractPhrases } = require('../api/extract');
 const { uploadPhrases, pollJob } = require('../api/upload');
 const { mergePayload } = require('../api/merge');
@@ -31,7 +31,7 @@ function isFolder(path) {
 
 class PushCommand extends Command {
   async run() {
-    const { args, flags } = this.parse(PushCommand);
+    const { args, flags } = await this.parse(PushCommand);
     const pwd = `${shelljs.pwd()}`;
     let filePattern = path.isAbsolute(args.pattern)
       ? args.pattern
@@ -61,7 +61,7 @@ class PushCommand extends Command {
     const payload = {};
     const tree = {};
 
-    const bar = cli.progress({
+    const bar = CliUx.ux.progress({
       format: '⸨{bar}⸩ {value}/{total} {file}',
       barCompleteChar: '\u2588',
       barIncompleteChar: '⠂',
@@ -160,7 +160,7 @@ class PushCommand extends Command {
       const uploadMessage = 'Uploading content to Transifex';
 
       this.log('');
-      cli.action.start(uploadMessage, '', { stdout: true });
+      CliUx.ux.action.start(uploadMessage, '', { stdout: true });
       try {
         let res = await uploadPhrases(payload, {
           url: cdsHost,
@@ -170,7 +170,7 @@ class PushCommand extends Command {
         });
 
         if (flags['no-wait']) {
-          cli.action.stop('Queued'.green);
+          CliUx.ux.action.stop('Queued'.green);
           return;
         }
 
@@ -178,7 +178,7 @@ class PushCommand extends Command {
         const jobUrl = `${cdsHost}${res.jobUrl}`;
         let status = '';
         do {
-          await cli.wait(1500);
+          await CliUx.ux.wait(1500);
           res = await pollJob({
             url: jobUrl,
             token: projectToken,
@@ -188,10 +188,10 @@ class PushCommand extends Command {
             status = res.status;
             switch (status) {
               case 'pending':
-                cli.action.start(uploadMessage, 'In queue', { stdout: true });
+                CliUx.ux.action.start(uploadMessage, 'In queue', { stdout: true });
                 break;
               case 'processing':
-                cli.action.start(uploadMessage, 'Processing', { stdout: true });
+                CliUx.ux.action.start(uploadMessage, 'Processing', { stdout: true });
                 break;
               default:
                 break;
@@ -200,7 +200,7 @@ class PushCommand extends Command {
         } while (status === 'pending' || status === 'processing');
 
         if (status === 'completed') {
-          cli.action.stop('Success'.green);
+          CliUx.ux.action.stop('Success'.green);
           this.log(`${'✓'.green} Successfully pushed strings to Transifex:`);
           if (res.created > 0) {
             this.log(`  Created strings: ${res.created.toString().green}`);
@@ -218,20 +218,20 @@ class PushCommand extends Command {
             this.log(`  Failed strings: ${res.failed.toString().red}`);
           }
         } else {
-          cli.action.stop('Failed'.red);
+          CliUx.ux.action.stop('Failed'.red);
         }
         _.each(res.errors, (error) => {
           this.log(`Error: ${JSON.stringify(error).red}`);
         });
       } catch (err) {
-        cli.action.stop('Failed'.red);
+        CliUx.ux.action.stop('Failed'.red);
         this.error(err);
       }
     }
   }
 }
 
-PushCommand.description = `detect and push source content to Transifex
+PushCommand.description = `Detect and push source content to Transifex
 Parse .js, .ts, .jsx, .tsx and .html files and detect phrases marked for
 translation by Transifex Native toolkit for Javascript and
 upload them to Transifex for translation.
@@ -269,53 +269,53 @@ PushCommand.args = [{
 }];
 
 PushCommand.flags = {
-  'dry-run': flags.boolean({
+  'dry-run': Flags.boolean({
     description: 'dry run, do not push to Transifex',
     default: false,
   }),
-  verbose: flags.boolean({
+  verbose: Flags.boolean({
     char: 'v',
     description: 'verbose output',
     default: false,
   }),
-  purge: flags.boolean({
+  purge: Flags.boolean({
     description: 'purge content on Transifex',
     default: false,
   }),
-  'no-wait': flags.boolean({
+  'no-wait': Flags.boolean({
     description: 'disable polling for upload results',
     default: false,
   }),
-  token: flags.string({
+  token: Flags.string({
     description: 'native project public token',
     default: '',
   }),
-  secret: flags.string({
+  secret: Flags.string({
     description: 'native project secret',
     default: '',
   }),
-  'append-tags': flags.string({
+  'append-tags': Flags.string({
     description: 'append tags to strings',
     default: '',
   }),
-  'with-tags-only': flags.string({
+  'with-tags-only': Flags.string({
     description: 'push strings with specific tags',
     default: '',
   }),
-  'without-tags-only': flags.string({
+  'without-tags-only': Flags.string({
     description: 'push strings without specific tags',
     default: '',
   }),
-  'cds-host': flags.string({
+  'cds-host': Flags.string({
     description: 'CDS host URL',
     default: '',
   }),
-  parser: flags.string({
+  parser: Flags.string({
     description: 'file parser to use',
     default: 'auto',
     options: ['auto', 'i18next'],
   }),
-  'key-generator': flags.string({
+  'key-generator': Flags.string({
     description: 'use hashed or source based keys',
     default: 'source',
     options: ['source', 'hash'],

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -1,1 +1,3 @@
-module.exports = require('@oclif/command');
+const { run } = require('@oclif/core');
+
+module.exports = run;


### PR DESCRIPTION
Update @transifex/cli to use `@oclif/core` instead of the older deprecated oclif libraries.
Also drops the unsupported [cli-ux](https://www.npmjs.com/package/cli-ux) library.

Changes are following the [official migration guide](https://github.com/oclif/core/blob/main/MIGRATION.md).

