### PR TITLE
@transifex/cli Add support for server-side dry run

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -110,7 +110,8 @@ OPTIONS
   -v, --verbose                          verbose output
   --append-tags=append-tags              append tags to strings
   --cds-host=cds-host                    CDS host URL
-  --dry-run                              dry run, do not push to Transifex
+  --dry-run                              dry run, do not apply changes in Transifex
+  --fake                                 do not push content to remote server
   --key-generator=source|hash            [default: source] use hashed or source based keys
   --no-wait                              disable polling for upload results
   --parser=auto|i18next                  [default: auto] file parser to use
@@ -140,6 +141,7 @@ DESCRIPTION
   txjs-cli push /home/repo/src
   txjs-cli push "*.js"
   txjs-cli push --dry-run
+  txjs-cli push --fake -v
   txjs-cli push --no-wait
   txjs-cli push --key-generator=hash
   txjs-cli push --append-tags="master,release:2.5"

--- a/packages/cli/src/api/upload.js
+++ b/packages/cli/src/api/upload.js
@@ -18,6 +18,7 @@ async function uploadPhrases(payload, params) {
     data: payload,
     meta: {
       purge: !!params.purge,
+      dry_run: !!params.dry_run,
     },
   }, {
     headers: {

--- a/packages/cli/src/commands/push.js
+++ b/packages/cli/src/commands/push.js
@@ -137,7 +137,7 @@ class PushCommand extends Command {
       }
     }
 
-    if (!flags['dry-run']) {
+    if (!flags.fake) {
       if (_.isEmpty(payload)) {
         this.log('⚠ Nothing to upload.'.yellow);
         process.exit();
@@ -157,7 +157,9 @@ class PushCommand extends Command {
         process.exit();
       }
 
-      const uploadMessage = 'Uploading content to Transifex';
+      const uploadMessage = flags['dry-run']
+        ? 'Uploading content to Transifex (dry run, no changes will be applied)'
+        : 'Uploading content to Transifex';
 
       this.log('');
       CliUx.ux.action.start(uploadMessage, '', { stdout: true });
@@ -167,6 +169,7 @@ class PushCommand extends Command {
           token: projectToken,
           secret: projectSecret,
           purge: flags.purge,
+          dry_run: flags['dry-run'],
         });
 
         if (flags['no-wait']) {
@@ -251,6 +254,7 @@ txjs-cli push src/
 txjs-cli push /home/repo/src
 txjs-cli push "*.js"
 txjs-cli push --dry-run
+txjs-cli push --fake -v
 txjs-cli push --no-wait
 txjs-cli push --key-generator=hash
 txjs-cli push --append-tags="master,release:2.5"
@@ -270,7 +274,11 @@ PushCommand.args = [{
 
 PushCommand.flags = {
   'dry-run': Flags.boolean({
-    description: 'dry run, do not push to Transifex',
+    description: 'dry run, do not apply changes in Transifex',
+    default: false,
+  }),
+  fake: Flags.boolean({
+    description: 'do not push content to remote server',
     default: false,
   }),
   verbose: Flags.boolean({


### PR DESCRIPTION
Make use of CDS dry_run meta flag when pushing content, and emulate the push command without actually applying changes in the Transifex content.