### PR TITLE
@transifex/cli Add pull command for offline caching

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -78,6 +78,7 @@ $ npm run push
 # Commands
 * [`txjs-cli help [COMMAND]`](#txjs-cli-help-command)
 * [`txjs-cli push [PATTERN]`](#txjs-cli-push-pattern)
+* [`txjs-cli pull [PATTERN]`](#txjs-cli-pull-pattern)
 * [`txjs-cli invalidate`](#txjs-cli-invalidate)
 
 ## `txjs-cli help [COMMAND]`
@@ -150,6 +151,54 @@ DESCRIPTION
   txjs-cli push --token=mytoken --secret=mysecret
   txjs-cli push en.json --parser=i18next
   TRANSIFEX_TOKEN=mytoken TRANSIFEX_SECRET=mysecret txjs-cli push
+```
+
+## `txjs-cli pull [PATTERN]`
+
+Pull content from Transifex for offline caching
+
+```
+USAGE
+  $ txjs-cli pull [--token <value>] [--secret <value>] [-f
+    <value>] [-l <value>] [--pretty] [--filter-tags <value>] [--cds-host
+    <value>]
+
+FLAGS
+  -f, --folder=<value>   output as files to folder
+  -l, --locale=<value>   pull specific language locale code
+  --cds-host=<value>     CDS host URL
+  --filter-tags=<value>  filter over specific tags
+  --pretty               beautify JSON output
+  --secret=<value>       native project secret
+  --token=<value>        native project public token
+
+DESCRIPTION
+  Pull content from Transifex for offline caching
+  Get content as JSON files, to be used by mobile Javascript SDKs for
+  offline support or warming up the cache with initial translations.
+
+  By default, JSON files are printed in the console,
+  unless the "-f foldername" parameter is provided. In that case
+  the JSON files will be downloaded to that folder with the <locale>.json
+  format.
+
+  To pull content some environment variables must be set:
+  TRANSIFEX_TOKEN=<Transifex Native Project Token>
+  TRANSIFEX_SECRET=<Transifex Native Project Secret>
+  (optional) TRANSIFEX_CDS_HOST=<CDS HOST>
+
+  or passed as --token=<TOKEN> --secret=<SECRET> parameters
+
+  Default CDS Host is https://cds.svc.transifex.net
+
+  Examples:
+  txjs-cli pull
+  txjs-cli pull --pretty
+  txjs-cli pull -f languages/
+  txjs-cli pull --lang=fr -f .
+  txjs-cli pull --filter-tags="foo,bar"
+  txjs-cli pull --token=mytoken --secret=mysecret
+  TRANSIFEX_TOKEN=mytoken TRANSIFEX_SECRET=mysecret txjs-cli pull
 ```
 
 ## `txjs-cli invalidate`

--- a/packages/cli/src/api/download.js
+++ b/packages/cli/src/api/download.js
@@ -1,0 +1,74 @@
+const axios = require('axios');
+const { version } = require('../../package.json');
+const { sleep } = require('./utils');
+
+/**
+ * Download languages
+ *
+ * @param {*} { cdsHost, token, secret }
+ * @return {Promise}
+ */
+async function downloadLanguages({ cdsHost, token, secret }) {
+  let response;
+  let lastResponseStatus = 202;
+  while (lastResponseStatus === 202) {
+    /* eslint-disable no-await-in-loop */
+    response = await axios.get(`${cdsHost}/languages`, {
+      headers: {
+        Authorization: `Bearer ${token}:${secret}`,
+        'Accept-version': 'v2',
+        'Content-Type': 'application/json;charset=utf-8',
+        'X-NATIVE-SDK': `txjs/cli/${version}`,
+      },
+    });
+    lastResponseStatus = response.status;
+    if (lastResponseStatus === 202) {
+      await sleep(1000);
+    }
+    /* eslint-enable no-await-in-loop */
+  }
+
+  return response.data;
+}
+
+/**
+ * Download phrases
+ *
+ * @param {*} {
+ *   cdsHost, locale, filterTags, token, secret,
+ * }
+ * @return {Promise}
+ */
+async function downloadPhrases({
+  cdsHost, locale, filterTags, token, secret,
+}) {
+  let response;
+  let lastResponseStatus = 202;
+  while (lastResponseStatus === 202) {
+    let url = `${cdsHost}/content/${locale}`;
+    if (filterTags) {
+      url = `${url}?filter[tags]=${filterTags}`;
+    }
+    /* eslint-disable no-await-in-loop */
+    response = await axios.get(url, {
+      headers: {
+        Authorization: `Bearer ${token}:${secret}`,
+        'Accept-version': 'v2',
+        'Content-Type': 'application/json;charset=utf-8',
+        'X-NATIVE-SDK': `txjs/cli/${version}`,
+      },
+    });
+    lastResponseStatus = response.status;
+    if (lastResponseStatus === 202) {
+      await sleep(1000);
+    }
+    /* eslint-enable no-await-in-loop */
+  }
+
+  return response.data;
+}
+
+module.exports = {
+  downloadPhrases,
+  downloadLanguages,
+};

--- a/packages/cli/src/api/utils.js
+++ b/packages/cli/src/api/utils.js
@@ -23,7 +23,22 @@ function mergeArrays(array1, array2) {
   return _.uniq(_.concat(array1 || [], array2 || []));
 }
 
+/**
+ * Async/await sleep
+ *
+ * @param {Number} msec
+ * @return {Promise}
+ */
+function sleep(msec) {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve();
+    }, msec);
+  });
+}
+
 module.exports = {
   stringToArray,
   mergeArrays,
+  sleep,
 };

--- a/packages/cli/src/commands/pull.js
+++ b/packages/cli/src/commands/pull.js
@@ -1,0 +1,135 @@
+/* eslint-disable no-await-in-loop */
+require('@colors/colors');
+const _ = require('lodash');
+const fs = require('fs');
+const path = require('path');
+const { Command, Flags } = require('@oclif/core');
+const { CliUx } = require('@oclif/core');
+const { downloadLanguages, downloadPhrases } = require('../api/download');
+
+class PullCommand extends Command {
+  async run() {
+    const { flags } = await this.parse(PullCommand);
+
+    let cdsHost = process.env.TRANSIFEX_CDS_HOST || 'https://cds.svc.transifex.net';
+    let projectToken = process.env.TRANSIFEX_TOKEN;
+    let projectSecret = process.env.TRANSIFEX_SECRET;
+
+    if (flags.token) projectToken = flags.token;
+    if (flags.secret) projectSecret = flags.secret;
+    if (flags['cds-host']) cdsHost = flags['cds-host'];
+
+    if (!projectToken || !projectSecret) {
+      this.log(`${'✘'.red} Cannot pull content, credentials are missing.`);
+      this.log('Tip: Set TRANSIFEX_TOKEN and TRANSIFEX_SECRET environment variables'.yellow);
+      process.exit();
+    }
+
+    try {
+      // get source lang
+      const params = {
+        cdsHost,
+        token: projectToken,
+        secret: projectSecret,
+        filterTags: flags['filter-tags'],
+        locale: '',
+      };
+      const locales = [];
+      if (flags.locale) {
+        locales.push(flags.locale);
+      } else {
+        CliUx.ux.action.start('Getting available languages', '', { stdout: true });
+        const languages = await downloadLanguages(params);
+        _.each(languages.data, (entry) => {
+          if (entry.code) {
+            locales.push(entry.code);
+          }
+        });
+      }
+      for (let i = 0; i < locales.length; i += 1) {
+        params.locale = locales[i];
+        CliUx.ux.action.start(
+          `Pulling content for ${params.locale.green} locale (${i + 1} of ${locales.length})`,
+          '',
+          { stdout: true },
+        );
+        const { data } = await downloadPhrases(params);
+        const json = flags.pretty ? JSON.stringify(data, null, 2) : JSON.stringify(data);
+        if (flags.folder) {
+          fs.writeFileSync(path.join(flags.folder, `${params.locale}.json`), json);
+        }
+        if (!flags.folder) {
+          this.log(json);
+        }
+      }
+      CliUx.ux.action.stop('Done'.green);
+    } catch (err) {
+      CliUx.ux.action.stop('Failed'.red);
+      this.error(err);
+    }
+  }
+}
+
+PullCommand.description = `Pull content from Transifex for offline caching
+Get content as JSON files, to be used by mobile Javascript SDKs for
+offline support or warming up the cache with initial translations.
+
+By default, JSON files are printed in the console,
+unless the "-f foldername" parameter is provided. In that case
+the JSON files will be downloaded to that folder with the <locale>.json format.
+
+To pull content some environment variables must be set:
+TRANSIFEX_TOKEN=<Transifex Native Project Token>
+TRANSIFEX_SECRET=<Transifex Native Project Secret>
+(optional) TRANSIFEX_CDS_HOST=<CDS HOST>
+
+or passed as --token=<TOKEN> --secret=<SECRET> parameters
+
+Default CDS Host is https://cds.svc.transifex.net
+
+Examples:
+txjs-cli pull
+txjs-cli pull --pretty
+txjs-cli pull -f languages/
+txjs-cli pull --lang=fr -f .
+txjs-cli pull --filter-tags="foo,bar"
+txjs-cli pull --token=mytoken --secret=mysecret
+TRANSIFEX_TOKEN=mytoken TRANSIFEX_SECRET=mysecret txjs-cli pull
+`;
+
+PullCommand.args = [];
+
+PullCommand.flags = {
+  token: Flags.string({
+    description: 'native project public token',
+    default: '',
+  }),
+  secret: Flags.string({
+    description: 'native project secret',
+    default: '',
+  }),
+  folder: Flags.string({
+    char: 'f',
+    description: 'output as files to folder',
+    default: '',
+  }),
+  locale: Flags.string({
+    char: 'l',
+    description: 'pull specific language locale code',
+    default: '',
+  }),
+  pretty: Flags.boolean({
+    description: 'beautify JSON output',
+    default: false,
+  }),
+  'filter-tags': Flags.string({
+    description: 'filter over specific tags',
+    default: '',
+  }),
+  'cds-host': Flags.string({
+    description: 'CDS host URL',
+    default: '',
+  }),
+};
+
+module.exports = PullCommand;

--- a/packages/cli/test/commands/pull.test.js
+++ b/packages/cli/test/commands/pull.test.js
@@ -1,0 +1,72 @@
+/* globals describe */
+const { expect, test } = require('@oclif/test');
+
+describe('pull command', () => {
+  test
+    .nock('https://cds.svc.transifex.net', (api) => api
+      .get('/languages')
+      .reply(200, {
+        data: [{
+          code: 'en',
+          name: 'English',
+          localized_name: 'English',
+          rtl: false,
+        }],
+        meta: { source_lang_code: 'en' },
+      }))
+    .nock('https://cds.svc.transifex.net', (api) => api
+      .get('/content/en')
+      .reply(200, {
+        data: [{
+          foo: 'bar',
+        }],
+      }))
+    .stdout()
+    .command(['pull', '--secret=s', '--token=t'])
+    .it('pulls content', (ctx) => {
+      expect(ctx.stdout).to.contain('foo');
+      expect(ctx.stdout).to.contain('bar');
+    });
+
+  test
+    .nock('https://cds.svc.transifex.net', (api) => api
+      .get('/content/fr')
+      .reply(200, {
+        data: [{
+          foo: 'bar',
+        }],
+      }))
+    .stdout()
+    .command(['pull', '-l=fr', '--secret=s', '--token=t'])
+    .it('pulls content with locale filter', (ctx) => {
+      expect(ctx.stdout).to.contain('foo');
+      expect(ctx.stdout).to.contain('bar');
+    });
+
+  test
+    .nock('https://cds.svc.transifex.net', (api) => api
+      .get('/content/fr?filter[tags]=atag')
+      .reply(200, {
+        data: [{
+          foo: 'bar',
+        }],
+      }))
+    .stdout()
+    .command(['pull', '-l=fr', '--filter-tags=atag', '--secret=s', '--token=t'])
+    .it('pulls content with tags filter', (ctx) => {
+      expect(ctx.stdout).to.contain('foo');
+      expect(ctx.stdout).to.contain('bar');
+    });
+
+  test
+    .nock('https://cds.svc.transifex.net', (api) => api
+      .get('/languages')
+      .reply(403))
+    .stdout()
+    .stderr()
+    .command(['pull', '--secret=s', '--token=t'])
+    .exit(2)
+    .it('handles pull error', (ctx) => {
+      expect(ctx.stdout).to.contain('Failed');
+    });
+});


### PR DESCRIPTION
Add a "pull" command in the CLI, to allow pulling content for offline/warming-up content when needed, e.g. on React Native mobile apps.
