### PR TITLE
@transifex/cli Add support for pushing JSON files

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -102,28 +102,32 @@ detect and push source content to Transifex
 
 ```
 USAGE
-  $ txjs-cli push [PATTERN]
+  $ txjs-cli push [PATTERN] [--dry-run] [--fake] [-v] [--purge] [--no-wait] [--token <value>] [--secret <value>] [--append-tags <value>] [--with-tags-only <value>] [--without-tags-only <value>]
+    [--cds-host <value>] [--parser auto|i18next|txnativejson] [--key-generator source|hash]
 
 ARGUMENTS
-  PATTERN  [default: **/*.{js,jsx,ts,tsx,vue}] file pattern to scan for strings
+  PATTERN  [default: **/*.{js,jsx,ts,tsx,html,vue,pug,ejs}] file pattern to scan for strings
 
-OPTIONS
-  -v, --verbose                          verbose output
-  --append-tags=append-tags              append tags to strings
-  --cds-host=cds-host                    CDS host URL
-  --dry-run                              dry run, do not apply changes in Transifex
-  --fake                                 do not push content to remote server
-  --key-generator=source|hash            [default: source] use hashed or source based keys
-  --no-wait                              disable polling for upload results
-  --parser=auto|i18next                  [default: auto] file parser to use
-  --purge                                purge content on Transifex
-  --secret=secret                        native project secret
-  --token=token                          native project public token
-  --with-tags-only=with-tags-only        push strings with specific tags
-  --without-tags-only=without-tags-only  push strings without specific tags
+FLAGS
+  -v, --verbose                verbose output
+  --append-tags=<value>        append tags to strings
+  --cds-host=<value>           CDS host URL
+  --dry-run                    dry run, do not apply changes in Transifex
+  --fake                       do not push content to remote server
+  --key-generator=<option>     [default: source] use hashed or source based keys
+                               <options: source|hash>
+  --no-wait                    disable polling for upload results
+  --parser=<option>            [default: auto] file parser to use
+                               <options: auto|i18next|txnativejson>
+  --purge                      purge content on Transifex
+  --secret=<value>             native project secret
+  --token=<value>              native project public token
+  --with-tags-only=<value>     push strings with specific tags
+  --without-tags-only=<value>  push strings without specific tags
 
 DESCRIPTION
-  Parse .js, .ts, .jsx, .tsx, .html and .vue files and detect phrases marked for
+  Detect and push source content to Transifex
+  Parse .js, .ts, .jsx, .tsx and .html files and detect phrases marked for
   translation by Transifex Native toolkit for Javascript and
   upload them to Transifex for translation.
 
@@ -150,6 +154,7 @@ DESCRIPTION
   txjs-cli push --without-tags-only="custom"
   txjs-cli push --token=mytoken --secret=mysecret
   txjs-cli push en.json --parser=i18next
+  txjs-cli push en.json --parser=txnativejson
   TRANSIFEX_TOKEN=mytoken TRANSIFEX_SECRET=mysecret txjs-cli push
 ```
 
@@ -207,20 +212,21 @@ invalidate and refresh CDS cache
 
 ```
 USAGE
-  $ txjs-cli invalidate
+  $ txjs-cli invalidate [--purge] [--token <value>] [--secret <value>] [--cds-host <value>]
 
-OPTIONS
-  --cds-host=cds-host  CDS host URL
-  --purge              force delete CDS cached content
-  --secret=secret      native project secret
-  --token=token        native project public token
+FLAGS
+  --cds-host=<value>  CDS host URL
+  --purge             force delete CDS cached content
+  --secret=<value>    native project secret
+  --token=<value>     native project public token
 
 DESCRIPTION
+  Invalidate and refresh CDS cache
   Content for delivery is cached in CDS and refreshed automatically every hour.
   This command triggers a refresh of cached content on the fly.
 
-  By default, invalidation does not remove existing cached content, but
-  starts the process of updating with latest translations from Transifex.
+  By default, invalidation does not remove existing cached content,
+  but starts the process of updating with latest translations from Transifex.
 
   Passing the --purge option, cached content will be forced to be deleted,
   however use that with caution, as it may introduce downtime of

--- a/packages/cli/src/api/extract.js
+++ b/packages/cli/src/api/extract.js
@@ -10,6 +10,7 @@ const { parseHTMLTemplateFile } = require('./parsers/angularHTML');
 const { babelExtractPhrases } = require('./parsers/babel');
 const { extractVuePhrases } = require('./parsers/vue');
 const { extractI18NextPhrases } = require('./parsers/i18next');
+const { extractTXNativeJSONPhrases } = require('./parsers/txnativejson');
 
 /**
  * Parse file and extract phrases using AST
@@ -31,6 +32,12 @@ function extractPhrases(file, relativeFile, options = {}) {
   // i18next JSON
   if (options.parser === 'i18next') {
     extractI18NextPhrases(HASHES, source, relativeFile, options);
+    return HASHES;
+  }
+
+  // Transifex Native JSON
+  if (options.parser === 'txnativejson') {
+    extractTXNativeJSONPhrases(HASHES, source, relativeFile, options);
     return HASHES;
   }
 

--- a/packages/cli/src/api/parsers/txnativejson.js
+++ b/packages/cli/src/api/parsers/txnativejson.js
@@ -1,0 +1,41 @@
+const _ = require('lodash');
+const { mergePayload } = require('../merge');
+
+/**
+ * Parse i18next JSON v3 & v4 files
+ *
+ * @param {Object} HASHES A map of keys and content for phrases
+ * @param {String} source The content we want to parse
+ * @param {String} relativeFile occurence
+ * @param {Object} options
+ * @param {String[]} options.appendTags
+ * @param {String[]} options.filterWithTags
+ * @param {String[]} options.filterWithoutTags
+ * @param {Boolean} options.useHashedKeys
+ */
+function extractTXNativeJSONPhrases(HASHES, source, relativeFile, options) {
+  let json = {};
+  try {
+    json = JSON.parse(source);
+  } catch (err) {
+    return;
+  }
+  _.each(json, (value, key) => {
+    mergePayload(HASHES, {
+      [key]: value,
+    });
+    if (options.appendTags) {
+      mergePayload(HASHES, {
+        [key]: {
+          meta: {
+            tags: options.appendTags,
+          },
+        },
+      });
+    }
+  });
+}
+
+module.exports = {
+  extractTXNativeJSONPhrases,
+};

--- a/packages/cli/src/commands/push.js
+++ b/packages/cli/src/commands/push.js
@@ -262,6 +262,7 @@ txjs-cli push --with-tags-only="home,error"
 txjs-cli push --without-tags-only="custom"
 txjs-cli push --token=mytoken --secret=mysecret
 txjs-cli push en.json --parser=i18next
+txjs-cli push en.json --parser=txnativejson
 TRANSIFEX_TOKEN=mytoken TRANSIFEX_SECRET=mysecret txjs-cli push
 `;
 
@@ -321,7 +322,7 @@ PushCommand.flags = {
   parser: Flags.string({
     description: 'file parser to use',
     default: 'auto',
-    options: ['auto', 'i18next'],
+    options: ['auto', 'i18next', 'txnativejson'],
   }),
   'key-generator': Flags.string({
     description: 'use hashed or source based keys',

--- a/packages/cli/test/api/extract.txnativejson.test.js
+++ b/packages/cli/test/api/extract.txnativejson.test.js
@@ -1,0 +1,19 @@
+/* globals describe, it */
+
+const { expect } = require('chai');
+const { extractPhrases } = require('../../src/api/extract');
+
+describe('extractPhrases with TXNativeJSON parser', () => {
+  it('works with json', async () => {
+    expect(await extractPhrases('test/fixtures/txnative.json', 'txnative.json', { parser: 'txnativejson' }))
+      .to.deep.equal({
+        key1: {
+          string: 'str1',
+          meta: { tags: ['tag1', 'tag2'] },
+        },
+        key2: {
+          string: 'str2',
+        },
+      });
+  });
+});

--- a/packages/cli/test/fixtures/txnative.json
+++ b/packages/cli/test/fixtures/txnative.json
@@ -1,0 +1,11 @@
+{
+  "key1": {
+    "string": "str1",
+    "meta": {
+      "tags": ["tag1", "tag2"]
+    }
+  },
+  "key2": {
+    "string": "str2"
+  }
+}


### PR DESCRIPTION
Adds support for `txjs-cli push source.json --parser=txnativejson` commands, to allow users to push content from JSON files, e.g. extracted from databases or other sources. 

The JSON format is following the CDS data payload format:
```
{
    <key>: {
      string: <string>,
      meta: {
        context: <string>
        developer_comment: <string>,
        character_limit: <number>,
        tags: <array>,
        occurrences: <array>,
      }
    }
    <key>: { .. }
}
```

with `meta` field treated as optional.