### PR TITLE
Add support for filtering content by translation status

### DIFF
--- a/packages/angular/projects/tx-native-angular-sdk/README.md
+++ b/packages/angular/projects/tx-native-angular-sdk/README.md
@@ -298,6 +298,7 @@ export interface ITranslationServiceConfig {
   token: string;
   cdsHost?: string;
   filterTags?: string;
+  filterStatus?: string;
   cache?: () => void;
   missingPolicy?: IPolicy;
   errorPolicy?: IPolicy;

--- a/packages/angular/projects/tx-native-angular-sdk/src/lib/interfaces.ts
+++ b/packages/angular/projects/tx-native-angular-sdk/src/lib/interfaces.ts
@@ -3,6 +3,7 @@ export interface ITranslationServiceConfig {
   token: string;
   cdsHost?: string;
   filterTags?: string;
+  filterStatus?: string;
   cache?: () => void;
   missingPolicy?: IPolicy;
   errorPolicy?: IPolicy;

--- a/packages/angular/projects/tx-native-angular-sdk/tests/translation.service.spec.ts
+++ b/packages/angular/projects/tx-native-angular-sdk/tests/translation.service.spec.ts
@@ -13,6 +13,7 @@ describe('TranslationService', () => {
     cdsHost: '',
     errorPolicy: undefined,
     filterTags: '',
+    filterStatus: '',
     missingPolicy: undefined,
     stringRenderer: undefined,
   };

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -164,18 +164,18 @@ Pull content from Transifex for offline caching
 
 ```
 USAGE
-  $ txjs-cli pull [--token <value>] [--secret <value>] [-f
-    <value>] [-l <value>] [--pretty] [--filter-tags <value>] [--cds-host
-    <value>]
+  $ txjs-cli pull [--token <value>] [--secret <value>] [-f <value>] [-l <value>] [--pretty] [--filter-tags <value>] [--filter-status reviewed|proofread|finalized] [--cds-host <value>]
 
 FLAGS
-  -f, --folder=<value>   output as files to folder
-  -l, --locale=<value>   pull specific language locale code
-  --cds-host=<value>     CDS host URL
-  --filter-tags=<value>  filter over specific tags
-  --pretty               beautify JSON output
-  --secret=<value>       native project secret
-  --token=<value>        native project public token
+  -f, --folder=<value>      output as files to folder
+  -l, --locale=<value>      pull specific language locale code
+  --cds-host=<value>        CDS host URL
+  --filter-status=<option>  filter over translation status
+                            <options: reviewed|proofread|finalized>
+  --filter-tags=<value>     filter over specific tags
+  --pretty                  beautify JSON output
+  --secret=<value>          native project secret
+  --token=<value>           native project public token
 
 DESCRIPTION
   Pull content from Transifex for offline caching
@@ -184,8 +184,7 @@ DESCRIPTION
 
   By default, JSON files are printed in the console,
   unless the "-f foldername" parameter is provided. In that case
-  the JSON files will be downloaded to that folder with the <locale>.json
-  format.
+  the JSON files will be downloaded to that folder with the <locale>.json format.
 
   To pull content some environment variables must be set:
   TRANSIFEX_TOKEN=<Transifex Native Project Token>
@@ -200,8 +199,9 @@ DESCRIPTION
   txjs-cli pull
   txjs-cli pull --pretty
   txjs-cli pull -f languages/
-  txjs-cli pull --lang=fr -f .
+  txjs-cli pull --locale=fr -f .
   txjs-cli pull --filter-tags="foo,bar"
+  txjs-cli pull --filter-status="reviewed"
   txjs-cli pull --token=mytoken --secret=mysecret
   TRANSIFEX_TOKEN=mytoken TRANSIFEX_SECRET=mysecret txjs-cli pull
 ```

--- a/packages/cli/src/api/download.js
+++ b/packages/cli/src/api/download.js
@@ -35,20 +35,29 @@ async function downloadLanguages({ cdsHost, token, secret }) {
  * Download phrases
  *
  * @param {*} {
- *   cdsHost, locale, filterTags, token, secret,
+ *   cdsHost, locale, filterTags, filterStatus, token, secret,
  * }
  * @return {Promise}
  */
 async function downloadPhrases({
-  cdsHost, locale, filterTags, token, secret,
+  cdsHost, locale, filterTags, filterStatus, token, secret,
 }) {
   let response;
   let lastResponseStatus = 202;
   while (lastResponseStatus === 202) {
     let url = `${cdsHost}/content/${locale}`;
+
+    const getOptions = [];
     if (filterTags) {
-      url = `${url}?filter[tags]=${filterTags}`;
+      getOptions.push(`filter[tags]=${filterTags}`);
     }
+    if (filterStatus) {
+      getOptions.push(`filter[status]=${filterStatus}`);
+    }
+    if (getOptions.length) {
+      url = `${url}?${getOptions.join('&')}`;
+    }
+
     /* eslint-disable no-await-in-loop */
     response = await axios.get(url, {
       headers: {

--- a/packages/cli/src/commands/pull.js
+++ b/packages/cli/src/commands/pull.js
@@ -32,6 +32,7 @@ class PullCommand extends Command {
         token: projectToken,
         secret: projectSecret,
         filterTags: flags['filter-tags'],
+        filterStatus: flags['filter-status'],
         locale: '',
       };
       const locales = [];
@@ -91,8 +92,9 @@ Examples:
 txjs-cli pull
 txjs-cli pull --pretty
 txjs-cli pull -f languages/
-txjs-cli pull --lang=fr -f .
+txjs-cli pull --locale=fr -f .
 txjs-cli pull --filter-tags="foo,bar"
+txjs-cli pull --filter-status="reviewed"
 txjs-cli pull --token=mytoken --secret=mysecret
 TRANSIFEX_TOKEN=mytoken TRANSIFEX_SECRET=mysecret txjs-cli pull
 `;
@@ -125,6 +127,11 @@ PullCommand.flags = {
   'filter-tags': Flags.string({
     description: 'filter over specific tags',
     default: '',
+  }),
+  'filter-status': Flags.string({
+    description: 'filter over translation status',
+    default: '',
+    options: ['reviewed', 'proofread', 'finalized'],
   }),
   'cds-host': Flags.string({
     description: 'CDS host URL',

--- a/packages/cli/test/commands/pull.test.js
+++ b/packages/cli/test/commands/pull.test.js
@@ -60,6 +60,36 @@ describe('pull command', () => {
 
   test
     .nock('https://cds.svc.transifex.net', (api) => api
+      .get('/content/fr?filter[status]=reviewed')
+      .reply(200, {
+        data: [{
+          foo: 'bar',
+        }],
+      }))
+    .stdout()
+    .command(['pull', '-l=fr', '--filter-status=reviewed', '--secret=s', '--token=t'])
+    .it('pulls content with status filter', (ctx) => {
+      expect(ctx.stdout).to.contain('foo');
+      expect(ctx.stdout).to.contain('bar');
+    });
+
+  test
+    .nock('https://cds.svc.transifex.net', (api) => api
+      .get('/content/fr?filter[tags]=atag&filter[status]=reviewed')
+      .reply(200, {
+        data: [{
+          foo: 'bar',
+        }],
+      }))
+    .stdout()
+    .command(['pull', '-l=fr', '--filter-status=reviewed', '--filter-tags=atag', '--secret=s', '--token=t'])
+    .it('pulls content with status & tags filter', (ctx) => {
+      expect(ctx.stdout).to.contain('foo');
+      expect(ctx.stdout).to.contain('bar');
+    });
+
+  test
+    .nock('https://cds.svc.transifex.net', (api) => api
       .get('/languages')
       .reply(403))
     .stdout()

--- a/packages/native/README.md
+++ b/packages/native/README.md
@@ -142,6 +142,9 @@ tx.init({
   // Fetch only strings that contain specific tags from CDS, e.g. "master,react"
   filterTags: String,
 
+  // Fetch only strings matching translation status: reviewed,proofread,finalized
+  filterStatus: String,
+
   // Missing translation policy, defaults to "new SourceStringPolicy()"
   missingPolicy: Function,
 

--- a/packages/native/src/TxNative.js
+++ b/packages/native/src/TxNative.js
@@ -30,6 +30,7 @@ export default class TxNative {
     this.token = '';
     this.secret = '';
     this.filterTags = '';
+    this.filterStatus = '';
     this.fetchTimeout = 0;
     this.fetchInterval = 250;
     this.cache = new MemoryCache();
@@ -48,6 +49,7 @@ export default class TxNative {
    * @param {Object} params
    * @param {String} params.cdsHost
    * @param {String} params.filterTags
+   * @param {String} params.filterStatus
    * @param {String} params.token
    * @param {String} params.secret
    * @param {Number} params.fetchTimeout
@@ -65,6 +67,7 @@ export default class TxNative {
       'secret',
       'cache',
       'filterTags',
+      'filterStatus',
       'fetchTimeout',
       'fetchInterval',
       'missingPolicy',
@@ -203,8 +206,15 @@ export default class TxNative {
       while (lastResponseStatus === 202) {
         /* eslint-disable no-await-in-loop */
         let url = `${this.cdsHost}/content/${localeCode}`;
+        const getOptions = [];
         if (filterTags) {
-          url = `${url}?filter[tags]=${filterTags}`;
+          getOptions.push(`filter[tags]=${filterTags}`);
+        }
+        if (this.filterStatus) {
+          getOptions.push(`filter[status]=${this.filterStatus}`);
+        }
+        if (getOptions.length) {
+          url = `${url}?${getOptions.join('&')}`;
         }
         response = await axios.get(url, {
           headers: {

--- a/packages/native/tests/renderer.test.js
+++ b/packages/native/tests/renderer.test.js
@@ -1,11 +1,19 @@
-/* globals describe, it */
+/* globals describe, it, beforeEach */
 
 import { expect } from 'chai';
-import { tx, t } from '../src/index';
+import { createNativeInstance } from '../src/index';
 
 const NODE_VER = parseInt((process.version.split('.')[0]).replace('v', ''), 10);
 
 describe('String renderer', () => {
+  let t;
+  let tx;
+
+  beforeEach(() => {
+    tx = createNativeInstance();
+    t = tx.translate.bind(tx);
+  });
+
   it('renders with localized dates', async () => {
     const d = Date.parse('2020-02-01');
 
@@ -32,8 +40,6 @@ describe('String renderer', () => {
   });
 
   it('renders with custom renderer', async () => {
-    const oldRenderer = tx.stringRenderer;
-
     class CustomRenderer {
       // eslint-disable-next-line class-methods-use-this
       render() {
@@ -46,10 +52,5 @@ describe('String renderer', () => {
     });
 
     expect(t('Hello')).to.deep.equal('foo');
-
-    // revert
-    tx.init({
-      stringRenderer: oldRenderer,
-    });
   });
 });

--- a/packages/native/tests/t.test.js
+++ b/packages/native/tests/t.test.js
@@ -1,12 +1,20 @@
-/* globals describe, it */
+/* globals describe, it, beforeEach */
 
 import { expect } from 'chai';
 import {
-  tx, t, ThrowErrorPolicy, SourceErrorPolicy,
+  createNativeInstance, ThrowErrorPolicy, SourceErrorPolicy,
 } from '../src/index';
 import { generateKey } from '../src/utils';
 
 describe('t function', () => {
+  let t;
+  let tx;
+
+  beforeEach(() => {
+    tx = createNativeInstance();
+    t = tx.translate.bind(tx);
+  });
+
   it('translates string', () => {
     expect(t('Hello')).to.equal('Hello');
     expect(t('Hello {username}', { username: 'Joe' }))
@@ -39,8 +47,6 @@ describe('t function', () => {
   });
 
   it('uses error policy', () => {
-    const prevPolicy = tx.errorPolicy;
-
     tx.init({
       errorPolicy: new ThrowErrorPolicy(),
     });
@@ -52,10 +58,6 @@ describe('t function', () => {
     });
     expect(t('Hello {username}'))
       .to.equal('Hello {username}');
-
-    tx.init({
-      errorPolicy: prevPolicy,
-    });
   });
 
   it('handles plurals', () => {


### PR DESCRIPTION
Update `@transifex/native` & `@transifex/cli` to support the new `filterStatus: "reviewed|proofread|finalized"` option, that can be used to only fetch phrases based on their translation status.

Compatible with [CDS 2.5.0](https://github.com/transifex/transifex-delivery/releases/tag/2.5.0).
