### PR TITLE
Add Vue3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,11 @@ Transifex Native support for localizing Angular components.
 
 ## Transifex Native for Vue
 
-Transifex Native support for localizing Vue components.
+### Transifex Native support for localizing Vue2 components.
 [Read more](https://github.com/transifex/transifex-javascript/tree/master/packages/vue2)
+
+### Transifex Native support for localizing Vue3 components.
+[Read more](https://github.com/transifex/transifex-javascript/tree/master/packages/vue3)
 
 ## Transifex Native for ExpressJS
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,14 +29,14 @@
     "@colors/colors": "^1.5.0",
     "@oclif/core": "^1.20.4",
     "@transifex/native": "^4.3.0",
+    "@vue/compiler-sfc": "^3.2.45",
     "angular-html-parser": "^1.8.0",
     "axios": "^1.1.3",
     "ejs": "^3.1.8",
     "glob": "^8.0.3",
     "lodash": "^4.17.21",
     "pug": "^3.0.2",
-    "shelljs": "^0.8.5",
-    "vue-template-compiler": "^2.7.14"
+    "shelljs": "^0.8.5"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.26.10",

--- a/packages/cli/src/api/parsers/vue.js
+++ b/packages/cli/src/api/parsers/vue.js
@@ -1,11 +1,11 @@
 const _ = require('lodash');
-const vueTemplateCompiler = require('vue-template-compiler');
+const vueTemplateCompiler = require('@vue/compiler-sfc');
 const { createPayload, isPayloadValid } = require('./utils');
 const { mergePayload } = require('../merge');
 const { babelExtractPhrases } = require('./babel');
 
 /**
- * A function to traverse the AST provided by the vue-template-compiler package
+ * A function to traverse the AST provided by the vue/compiler-sfc package
  *
  * @param {*} ast
  * @param {*} visitor
@@ -14,7 +14,7 @@ function traverseVueTemplateAst(ast, visitor = {}) {
   // Use this in order to identify expressions in the AST since there is no
   // Tag to identify it with when traversing
   const VISITORS = {
-    2: 'Expression',
+    5: 'Expression',
   };
 
   function traverseArray(array, parent) {
@@ -28,10 +28,13 @@ function traverseVueTemplateAst(ast, visitor = {}) {
     if (visitor.enter) visitor.enter(node, parent);
     if (visitor[node.tag]) visitor[node.tag](node, parent);
     // Take care of expressions
-    if (visitor[VISITORS[node.type]] && node.expression) {
-      visitor[VISITORS[node.type]](node, parent);
+    if (visitor[VISITORS[node.type]] && node.content) {
+      if (node.content.loc.source) visitor[VISITORS[node.type]](node, parent);
     }
     if (node.children) traverseArray(node.children, node);
+    if (node.content) {
+      if (node.content.children) traverseArray(node.content.children, node);
+    }
     if (visitor.exit) visitor.exit(node, parent);
   }
   traverseNode(ast, null);
@@ -54,11 +57,11 @@ function vueElementVisitor(HASHES, relativeFile, options) {
   return (node) => {
     let string;
     const params = {};
-    _.each(node.attrsList, (attr) => {
+    _.each(node.props, (attr) => {
       const property = attr.name;
       if (!property || !attr.value) return;
 
-      const attrValue = attr.value;
+      const attrValue = attr.value.content;
 
       if (!attrValue) return;
 
@@ -102,25 +105,25 @@ function vueElementVisitor(HASHES, relativeFile, options) {
  */
 function extractVuePhrases(HASHES, source, relativeFile, options) {
   // Use the vue-template-compiler API to parse content
-  const vueContent = vueTemplateCompiler.parseComponent(source);
-
+  const vueContent = vueTemplateCompiler.parse(source);
   // Get the JS Content from the file and extract hashes/phrases with Babel
-  if (vueContent.script && vueContent.script.content) {
-    const script = vueContent.script.content;
+  if (vueContent.descriptor.script && vueContent.descriptor.script.content) {
+    const script = vueContent.descriptor.script.content;
     babelExtractPhrases(HASHES, script, relativeFile, options);
   }
 
   // Get the template content from the file and extract hashes/phrases with
   // custom traverse function
-  if (vueContent.template && vueContent.template.content) {
+  if (vueContent.descriptor.template && vueContent.descriptor.template.content) {
     // Compile to get the AST
-    const template = vueTemplateCompiler.compile(vueContent.template.content, {
-      preserveWhitespace: false,
+    const template = vueTemplateCompiler.compileTemplate({
+      id: 'sfc-compiler',
+      source: vueContent.descriptor.template.content,
     });
 
     traverseVueTemplateAst(template.ast, {
       Expression(node) {
-        babelExtractPhrases(HASHES, node.expression, relativeFile, options);
+        babelExtractPhrases(HASHES, node.content.loc.source, relativeFile, options);
       },
       T: vueElementVisitor(HASHES, relativeFile, options),
       UT: vueElementVisitor(HASHES, relativeFile, options),

--- a/packages/vue3/.eslintrc
+++ b/packages/vue3/.eslintrc
@@ -1,0 +1,7 @@
+{
+    "extends": ["airbnb-base"],
+    "rules": {
+      "no-underscore-dangle": "off"
+    },
+    "ignorePatterns": ["dist/"]
+}

--- a/packages/vue3/.npmignore
+++ b/packages/vue3/.npmignore
@@ -1,0 +1,4 @@
+tests
+.eslintrc.yml
+coverage
+tags

--- a/packages/vue3/README.md
+++ b/packages/vue3/README.md
@@ -1,0 +1,205 @@
+<p align="center">
+  <a href="https://www.transifex.com">
+    <img src="https://raw.githubusercontent.com/transifex/transifex-javascript/master/media/transifex.png" height="60">
+  </a>
+</p>
+<p align="center">
+  <i>Transifex Native is a full end-to-end, cloud-based localization stack for moderns apps.</i>
+</p>
+<p align="center">
+  <img src="https://github.com/transifex/transifex-javascript/actions/workflows/npm-publish.yml/badge.svg">
+  <a href="https://www.npmjs.com/package/@transifex/vue3">
+    <img src="https://img.shields.io/npm/v/@transifex/vue3.svg">
+  </a>
+  <a href="https://developers.transifex.com/docs/native">
+    <img src="https://img.shields.io/badge/docs-transifex.com-blue">
+  </a>
+</p>
+
+# Transifex Native SDK: Vue i18n
+
+Vue3 component for localizing Vue application using
+[Transifex Native](https://www.transifex.com/native/).
+
+Related packages:
+- [@transifex/native](https://www.npmjs.com/package/@transifex/native)
+- [@transifex/cli](https://www.npmjs.com/package/@transifex/cli)
+
+Learn more about Transifex Native in the [Transifex Developer Hub](https://developers.transifex.com/docs/native).
+
+# How it works
+
+**Step1**: Create a Transifex Native project in [Transifex](https://www.transifex.com).
+
+**Step2**: Grab credentials.
+
+**Step3**: Internationalize the code using the SDK.
+
+**Step4**: Push source phrases using the `@transifex/cli` tool.
+
+**Step5**: Translate the app using over-the-air updates.
+
+No translation files required.
+
+![native](https://raw.githubusercontent.com/transifex/transifex-javascript/master/media/native.gif)
+
+# Upgrade to v2
+
+If you are upgrading from the `1.x.x` version, please read this [migration guide](https://github.com/transifex/transifex-javascript/blob/HEAD/UPGRADE_TO_V2.md), as there are breaking changes in place.
+
+
+# Install
+
+Install the library and its dependencies using:
+
+```sh
+npm install @transifex/native @transifex/vue3 --save
+```
+
+# Usage
+
+## Initiate the plugin in a Vue App
+
+```javascript
+import { createApp } from 'vue';
+import App from './App.vue';
+import { tx } from '@transifex/native';
+import { TransifexVue } from '@transifex/vue3';
+
+tx.init({
+  token: '<token>',
+});
+
+const app = createApp(App);
+
+app.use(TransifexVue);
+app.mount('#app');
+
+```
+
+
+## `T` Component
+
+```javascript
+<template>
+  <div>
+    <T _str="Hello world" />
+    <T _str="Hello {username}" :username="user" />
+  </div>
+</template>
+
+<script>
+  export default {
+    name: 'App',
+    data() {
+      return {
+        user: 'John'
+      };
+    },
+  }
+</script>
+```
+
+Available optional props:
+
+| Prop       | Type   | Description                                 |
+|------------|--------|---------------------------------------------|
+| _context   | String | String context, affects key generation      |
+| _key       | String | Custom string key                           |
+| _comment   | String | Developer comment                           |
+| _charlimit | Number | Character limit instruction for translators |
+| _tags      | String | Comma separated list of tags                |
+
+
+## `UT` Component
+
+```javascript
+<template>
+  <div>
+      <UT _str="Hello <b>{username}</b>" :username="user" />
+      <p>
+        <UT _str="Hello <b>{username}</b>" :username="user" _inline="true" />
+      </p>
+  </div>
+</template>
+
+<script>
+  export default {
+    name: 'App',
+    data() {
+      return {
+        user: 'John'
+      };
+    },
+  }
+</script>
+```
+
+`UT` has the same behaviour as `T`, but renders source string as HTML inside a
+`div` tag.
+
+Available optional props: All the options of `T` plus:
+
+| Prop    | Type    | Description                                     |
+|---------|---------|-------------------------------------------------|
+| _inline | Boolean | Wrap translation in `span` |
+
+## `$t` template function or `this.t` alias for scripts
+
+Makes the current component re-render when a language change is detected and
+returns a t-function you can use to translate strings programmatically.
+
+You will most likely prefer to use the `T` or `UT` components over this, unless
+for some reason you want to have the translation output in a variable for
+manipulation.
+
+```javascript
+<template>
+  <div>
+    {{$t('Hello world').toLowerCase()}}
+    {{hellofromscript}}
+  </div>
+</template>
+
+<script>
+  export default {
+    name: 'App',
+    computed: {
+      hellofromscript: function() { return this.t('Hello world').toLowerCase() },
+    },
+  }
+</script>
+
+```
+
+## `LanguagePicker` component
+
+Renders a `<select>` tag that displays supported languages and switches the
+application's selected language on change.
+
+```javascript
+<template>
+  <div>
+    <T _str="This is a translatable message" />
+    <LanguagePicker />
+  </div>
+</template>
+
+<script>
+import { LanguagePicker } from '@transifex/vue3';
+  export default {
+    name: 'App',
+    components: {
+      LanguagePicker,
+    }
+  }
+</script>
+```
+
+Accepts properties:
+
+- `className`: The CSS class that will be applied to the `<select>` tag.
+
+# License
+
+Licensed under Apache License 2.0, see [LICENSE](https://github.com/transifex/transifex-javascript/blob/HEAD/LICENSE) file.

--- a/packages/vue3/babel.config.js
+++ b/packages/vue3/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: [['@babel/preset-env', { targets: { node: 'current' } }]],
+};

--- a/packages/vue3/package.json
+++ b/packages/vue3/package.json
@@ -1,0 +1,81 @@
+{
+  "name": "@transifex/vue3",
+  "version": "4.3.0",
+  "description": "Vue3 i18n framework using Transifex Native",
+  "keywords": [
+    "transifex",
+    "i18n",
+    "l10n",
+    "localization",
+    "internationalization",
+    "globalization",
+    "translation",
+    "vue",
+    "vue.js"
+  ],
+  "author": "Transifex",
+  "homepage": "https://github.com/transifex/transifex-javascript/tree/master/packages/vue3",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": "git://github.com/transifex/transifex-javascript.git",
+  "bugs": {
+    "url": "https://github.com/transifex/transifex-javascript/issues"
+  },
+  "engines": {
+    "node": ">=14.0.0"
+  },
+  "main": "dist/index.js",
+  "source": "src/index.js",
+  "scripts": {
+    "lint": "eslint src/ tests/",
+    "build": "NODE_ENV=production rollup -c --bundleConfigAsCjs",
+    "test": "run-s test:unit test:build",
+    "test:build": "run-s build",
+    "test:unit": "jest --coverage=true --forceExit",
+    "publish-npm": "npm publish"
+  },
+  "jest": {
+    "moduleFileExtensions": [
+      "js",
+      "vue"
+    ],
+    "transform": {
+      "^.+\\.js$": "babel-jest",
+      "^.+\\.vue$": "@vue/vue3-jest"
+    },
+    "testEnvironmentOptions": {
+      "customExportConditions": [
+        "node",
+        "node-addons"
+      ]
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "peerDependencies": {
+    "@transifex/native": "^4.3.0",
+    "vue": "^3.2.45"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.20.2",
+    "@babel/preset-env": "^7.20.2",
+    "@testing-library/jest-dom": "^5.16.5",
+    "@testing-library/vue": "^6.6.1",
+    "@transifex/native": "^4.3.0",
+    "@vue/compiler-sfc": "^3.2.45",
+    "@vue/vue3-jest": "^29.2.0",
+    "babel-jest": "^29.3.1",
+    "eslint": "^8.28.0",
+    "eslint-config-airbnb": "^19.0.4",
+    "eslint-plugin-import": "^2.26.0",
+    "jest": "^29.3.1",
+    "jest-environment-jsdom": "^29.3.1",
+    "npm-run-all": "^4.1.5",
+    "rollup": "^3.4.0",
+    "rollup-plugin-vue": "^6.0.0",
+    "vue": "^3.2.45"
+  }
+}

--- a/packages/vue3/rollup.config.js
+++ b/packages/vue3/rollup.config.js
@@ -1,0 +1,13 @@
+import VuePlugin from 'rollup-plugin-vue';
+
+export default [
+  {
+    input: 'src/index.js',
+    output: {
+      file: 'dist/index.js',
+      format: 'esm',
+    },
+    plugins: [VuePlugin()],
+    external: ['vue', '@transifex/native'],
+  },
+];

--- a/packages/vue3/src/components/LanguagePicker.vue
+++ b/packages/vue3/src/components/LanguagePicker.vue
@@ -1,0 +1,43 @@
+<template>
+  <select
+    :class="className"
+    v-model="selected"
+    @change="onChange($event)"
+  >
+    <option v-for="language in languages"
+      :key="language.code"
+      :value="language.code">
+      {{ language.name }}
+    </option>
+  </select>
+</template>
+
+<script>
+import { tx } from '@transifex/native';
+
+export default {
+  name: 'LanguagePicker',
+  props: {
+    className: {
+      type: String,
+    },
+  },
+  methods: {
+    async getLanguages() {
+      this.languages = await tx.getLanguages();
+    },
+    onChange(e) {
+      tx.setCurrentLocale(e.target.value);
+    },
+  },
+  mounted() {
+    this.getLanguages();
+  },
+  data() {
+    return {
+      selected: tx.getCurrentLocale(),
+      languages: tx.languages,
+    };
+  },
+};
+</script>

--- a/packages/vue3/src/components/T.js
+++ b/packages/vue3/src/components/T.js
@@ -1,0 +1,27 @@
+import {
+  onEvent, offEvent, LOCALE_CHANGED, tx, t,
+} from '@transifex/native';
+import { Text, h } from 'vue';
+
+export default {
+  name: 'T',
+  data() {
+    return {
+      lang: tx.getCurrentLocale(),
+    };
+  },
+  mounted() {
+    onEvent(LOCALE_CHANGED, (l) => {
+      this.$data.lang = l;
+    });
+  },
+  onbeforeunload() {
+    offEvent(LOCALE_CHANGED, (l) => {
+      this.$data.lang = l;
+    });
+  },
+  render() {
+    const string = t(this.$attrs._str, { ...this.$attrs }, this.$data.lang);
+    return h(Text, string);
+  },
+};

--- a/packages/vue3/src/components/UT.js
+++ b/packages/vue3/src/components/UT.js
@@ -1,0 +1,32 @@
+import {
+  onEvent, offEvent, LOCALE_CHANGED, tx, t,
+} from '@transifex/native';
+import { h } from 'vue';
+
+export default {
+  name: 'UT',
+  inheritAttrs: false,
+  functional: true,
+  data() {
+    return {
+      lang: tx.getCurrentLocale(),
+    };
+  },
+  mounted() {
+    onEvent(LOCALE_CHANGED, (l) => {
+      this.$data.lang = l;
+    });
+  },
+  onbeforeunload() {
+    offEvent(LOCALE_CHANGED, (l) => {
+      this.$data.lang = l;
+    });
+  },
+  render() {
+    const innerHTML = t(this.$attrs._str, { ...this.$attrs }, this.$data.lang);
+    const element = this.$attrs._inline ? 'span' : 'div';
+    return h(element, {
+      innerHTML,
+    });
+  },
+};

--- a/packages/vue3/src/index.js
+++ b/packages/vue3/src/index.js
@@ -1,0 +1,5 @@
+/* eslint import/prefer-default-export: 0 */
+export { default as LanguagePicker } from './components/LanguagePicker.vue';
+export { default as T } from './components/T';
+export { default as UT } from './components/UT';
+export { default as TransifexVue } from './native';

--- a/packages/vue3/src/native.js
+++ b/packages/vue3/src/native.js
@@ -1,0 +1,28 @@
+import {
+  onEvent, LOCALE_CHANGED, t, tx,
+} from '@transifex/native';
+import { ref } from 'vue';
+import T from './components/T';
+import UT from './components/UT';
+
+export default {
+  install(app) {
+    const locale = ref(tx.getCurrentLocale());
+
+    onEvent(LOCALE_CHANGED, (l) => {
+      locale.value = l;
+    });
+
+    // eslint-disable-next-line no-param-reassign
+    app.trans = (string, options) => t(string, options, locale.value);
+    app.mixin({
+      computed: {
+        $t() {
+          return (key, options) => app.trans(key, options);
+        },
+      },
+    });
+    app.component('T', T);
+    app.component('UT', UT);
+  },
+};

--- a/packages/vue3/tests/LanguagePicker.spec.js
+++ b/packages/vue3/tests/LanguagePicker.spec.js
@@ -1,0 +1,55 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/* globals test, beforeEach, afterEach, expect */
+import {
+  cleanup,
+  render,
+  screen,
+  waitFor,
+  fireEvent,
+} from '@testing-library/vue';
+
+import { tx } from '@transifex/native';
+import { LanguagePicker } from '../src/index';
+
+let oldGetLanguages;
+beforeEach(() => {
+  // Start mocking
+  oldGetLanguages = tx.getLanguages;
+  tx.getLanguages = async () => [
+    { code: 'el', name: 'Greek' },
+    { code: 'fr', name: 'French' },
+  ];
+});
+afterEach(() => {
+  // Reset mocking
+  tx.getLanguages = oldGetLanguages;
+  cleanup();
+});
+
+test('display language picker', async () => {
+  render(LanguagePicker);
+  await waitFor(() => screen.getByText('Greek'));
+  expect(screen.queryByText('Greek')).toBeTruthy();
+  expect(screen.queryByText('French')).toBeTruthy();
+});
+
+test('change language', async () => {
+  // Start mocking
+  const args = [];
+  const oldSetCurrentLocale = tx.setCurrentLocale;
+  tx.setCurrentLocale = function setCurrentLocaleMock(code) {
+    args.push(code);
+  };
+
+  render(LanguagePicker);
+  await waitFor(() => screen.getByText('Greek'));
+  const combobox = screen.getByRole('combobox');
+  await fireEvent.update(combobox, 'el');
+  expect(args).toEqual(['el']);
+
+  // Reset mocking
+  tx.setCurrentLocale = oldSetCurrentLocale;
+});

--- a/packages/vue3/tests/T.spec.js
+++ b/packages/vue3/tests/T.spec.js
@@ -1,0 +1,58 @@
+/**
+ * @jest-environment jsdom
+ */
+/* globals describe, it, expect, afterEach */
+
+import {
+  render, screen, cleanup, fireEvent,
+} from '@testing-library/vue';
+import '@testing-library/jest-dom';
+import { T } from '../src/index';
+
+describe('T', () => {
+  afterEach(cleanup);
+
+  it('renders text', () => {
+    const message = 'Hello <b>safe text</b>';
+    render(T, {
+      props: { _str: message },
+    });
+    expect(screen.queryByText(message)).toBeInTheDocument();
+  });
+
+  it('renders text with param', () => {
+    const message = 'Hello <b>{username}</b>';
+    render(T, {
+      props: {
+        _str: message,
+        username: 'JohnDoe',
+      },
+    });
+    expect(screen.queryByText('Hello <b>JohnDoe</b>')).toBeInTheDocument();
+  });
+
+  it('rerenders on prop change', async () => {
+    const MyComp = {
+      template: `
+          <div>
+            <input v-model="string" />
+            <p><T _str="hello {word}" :word="string" /></p>
+          </div>
+      `,
+      data() {
+        return {
+          string: '',
+        };
+      },
+      components: {
+        T,
+      },
+    };
+
+    render(MyComp);
+    const input = screen.getByRole('textbox');
+
+    await fireEvent.update(input, 'world');
+    expect(screen.getByText('hello world')).toBeTruthy();
+  });
+});

--- a/packages/vue3/tests/UT.spec.js
+++ b/packages/vue3/tests/UT.spec.js
@@ -1,0 +1,42 @@
+/**
+ * @jest-environment jsdom
+ */
+/* globals describe, it, expect, afterEach */
+
+import { render, screen, cleanup } from '@testing-library/vue';
+import '@testing-library/jest-dom';
+
+import { UT } from '../src/index';
+
+describe('UT', () => {
+  afterEach(cleanup);
+
+  it('renders HTML', () => {
+    const MyComp = {
+      template: `
+        <UT _str="Hello <b>Unsafe HTML</b>" />
+      `,
+      components: {
+        UT,
+      },
+    };
+    render(MyComp);
+    expect(screen.queryByText('Unsafe HTML')).toBeInTheDocument();
+    expect(screen.queryByText('Hello')).toBeInTheDocument();
+  });
+
+  it('renders inline HTML', () => {
+    const MyComp = {
+      template: `
+        <UT _str="Hello <b>Inline HTML</b>" _inline=true />
+      `,
+      components: {
+        UT,
+      },
+    };
+    const { container } = render(MyComp);
+    expect(screen.queryByText('Inline HTML')).toBeInTheDocument();
+    expect(screen.queryByText('Hello')).toBeInTheDocument();
+    expect(container.querySelector('span')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
In order to support Vue3 we had to drop `vue-template-compiler`
in favor of `@vue/compiler-sfc` for compatibility reasons. This
way we can now support both Vue2 and Vue3.

Side effects
`vue/compiler-sfc` ast result is more cryptic than the previous
dependency, so we might need to revisit in the future and
use an alternative.