### PR TITLE
Add regex for additional whitespaces in Angular template pipe syntax in CLI

### DIFF
--- a/packages/cli/src/api/parsers/angularHTML.js
+++ b/packages/cli/src/api/parsers/angularHTML.js
@@ -7,17 +7,17 @@ const { createPayload, isPayloadValid } = require('./utils');
 /**
  * Global regexp to find use of TranslatePipe.
  */
-const pipeRegexpG = /{{\s*?['|"]([\s\S]+?)['|"]\s*?\|\s*?translate\s*?:?({[\s\S]*?})?\s*?}}/gi;
+const pipeRegexpG = /{{\s*?['|"]([\s\S]+?)['|"]\s*?\|\s*?translate\s*?:?\s*?({[\s\S]*?})?\s*?}}/gi;
 
 /**
   * Regexp to find use of TranslatePipe and match with capture groups.
   */
-const pipeRegexp = /{{\s*?['|"]([\s\S]+?)['|"]\s*?\|\s*?translate\s*?:?({[\s\S]*?})?\s*?}}/i;
+const pipeRegexp = /{{\s*?['|"]([\s\S]+?)['|"]\s*?\|\s*?translate\s*?:?\s*?({[\s\S]*?})?\s*?}}/i;
 
 /**
   * Regexp to find use of TranslatePipe in Attributes;
   */
-const pipeBindingRegexp = /'([\s\S]+?)'\s*?\|\s*?translate\s*?:?({[\s\S]*?})?/i;
+const pipeBindingRegexp = /'([\s\S]+?)'\s*?\|\s*?translate\s*?:?\s*?({[\s\S]*?})?/i;
 
 /**
  * Loosely parses string (from HTML) to an object.

--- a/packages/cli/test/api/extract.hashedkeys.test.js
+++ b/packages/cli/test/api/extract.hashedkeys.test.js
@@ -344,6 +344,10 @@ describe('extractPhrases with hashed keys', () => {
           string: 'This is a sixth pipe text, no one should do this',
           meta: { context: [], tags: [], occurrences: ['angular-template.html'] },
         },
+        'text.pipe_text_seventh': {
+          string: 'This is a seventh pipe test for additional white spaces',
+          meta: { context: [], tags: [], occurrences: ['angular-template.html'] },
+        },
         '867b7cc4643da9b4c97ababa43c50c23': {
           string: 'Used in a {binding}',
           meta: { context: [], tags: [], occurrences: ['angular-template.html'] },

--- a/packages/cli/test/api/extract.sourcekeys.test.js
+++ b/packages/cli/test/api/extract.sourcekeys.test.js
@@ -325,6 +325,10 @@ describe('extractPhrases with source keys', () => {
           string: 'This is a sixth pipe text, no one should do this',
           meta: { context: [], tags: [], occurrences: ['angular-template.html'] },
         },
+        'text.pipe_text_seventh': {
+          string: 'This is a seventh pipe test for additional white spaces',
+          meta: { context: [], tags: [], occurrences: ['angular-template.html'] },
+        },
         'Used in a {binding}': {
           string: 'Used in a {binding}',
           meta: { context: [], tags: [], occurrences: ['angular-template.html'] },

--- a/packages/cli/test/fixtures/angular-template.html
+++ b/packages/cli/test/fixtures/angular-template.html
@@ -57,6 +57,10 @@
     }}}
   </p>
 
+  <p class="using-pipe-third">
+    {{ "This is a seventh pipe test for additional white spaces" |   translate:   { key: "text.pipe_text_seventh" } }}
+  </p>
+
   <p [matTooltip]="'Used in a {binding}' | translate">
     Inside a p
   </p>


### PR DESCRIPTION
Fixes issue where additional whitespaces in Angular pipe syntax causes the CLI not to pick up translation strings.

This is my first contribution here, let me know if anything is missing or needs to be changes.

closes #166 