### PR TITLE
Fix issue with Vue templates parsing

### DIFF
--- a/packages/cli/test/api/extract.hashedkeys.test.js
+++ b/packages/cli/test/api/extract.hashedkeys.test.js
@@ -406,6 +406,46 @@ describe('extractPhrases with hashed keys', () => {
           string: 'Text {someothervalue}',
           meta: { context: [], tags: [], occurrences: ['vuejs.vue'] },
         },
+        b1cb1acd2052787f97693d8eb660e366: {
+          meta: {
+            context: [],
+            occurrences: [
+              'vuejs.vue',
+            ],
+            tags: [],
+          },
+          string: 'Text 7',
+        },
+        bc34d6c4a81fe6764e851ef5c4597f9b: {
+          meta: {
+            context: [],
+            occurrences: [
+              'vuejs.vue',
+            ],
+            tags: [],
+          },
+          string: 'Text 8',
+        },
+        c2f94cf9d2c1065bc2ef5e766fa0f4ca: {
+          meta: {
+            context: [],
+            occurrences: [
+              'vuejs.vue',
+            ],
+            tags: [],
+          },
+          string: 'A prop string',
+        },
+        f6d3188db065ecf6b7b4165b030f3bc6: {
+          meta: {
+            context: [],
+            occurrences: [
+              'vuejs.vue',
+            ],
+            tags: [],
+          },
+          string: 'Text 9 with siblings',
+        },
         '57b0d93fc0e1c3af68a41214147efd97': {
           string: 'Text 5',
           meta: { context: [], tags: [], occurrences: ['vuejs.vue'] },

--- a/packages/cli/test/api/extract.sourcekeys.test.js
+++ b/packages/cli/test/api/extract.sourcekeys.test.js
@@ -395,6 +395,46 @@ describe('extractPhrases with source keys', () => {
           string: 'Text 6',
           meta: { context: [], tags: [], occurrences: ['vuejs.vue'] },
         },
+        'Text 7': {
+          meta: {
+            context: [],
+            occurrences: [
+              'vuejs.vue',
+            ],
+            tags: [],
+          },
+          string: 'Text 7',
+        },
+        'Text 8': {
+          meta: {
+            context: [],
+            occurrences: [
+              'vuejs.vue',
+            ],
+            tags: [],
+          },
+          string: 'Text 8',
+        },
+        'A prop string': {
+          meta: {
+            context: [],
+            occurrences: [
+              'vuejs.vue',
+            ],
+            tags: [],
+          },
+          string: 'A prop string',
+        },
+        'Text 9 with siblings': {
+          meta: {
+            context: [],
+            occurrences: [
+              'vuejs.vue',
+            ],
+            tags: [],
+          },
+          string: 'Text 9 with siblings',
+        },
       });
   });
 });

--- a/packages/cli/test/fixtures/vuejs.vue
+++ b/packages/cli/test/fixtures/vuejs.vue
@@ -15,6 +15,14 @@
       <UT _str="<b>HTML text</b>" _tags="tag1" />
       <UT _str="<b>HTML inline text</b>" _inline="true" />
       {{$t('Text 5')}}
+      <div>{{$t('Text 7')}}</div>
+      <div v-if="condition == 'something'">
+        <div>
+          <div><p>{{$t('Text 8')}}</p></div>
+        </div>
+      </div>
+      <span>{{ t(`Text 9 with siblings`) }}<sup>*</sup></span>
+      <SomeComponent :aprop="t('A prop string')"/>
   </div>
 </template>
 <script>


### PR DESCRIPTION
Fixes:

* `t` functions inside `v-if` were being ignored Now it utilises `branches` to understand if it's a condition and proceeds with parsing.
* Cases that a `t` expression would be sibling with an HTML element would be ignored. Type of `12` is added for parsing.
* Parsing of props.