### PR TITLE
Revert change about additional type (Vue)

### DIFF
--- a/packages/cli/src/api/parsers/vue.js
+++ b/packages/cli/src/api/parsers/vue.js
@@ -15,7 +15,6 @@ function traverseVueTemplateAst(ast, visitor = {}) {
   // Tag to identify it with when traversing
   const VISITORS = {
     5: 'Expression',
-    12: 'Expression',
   };
 
   function traverseArray(array, parent) {
@@ -35,6 +34,7 @@ function traverseVueTemplateAst(ast, visitor = {}) {
     if (node.children) traverseArray(node.children, node);
     if (node.content) {
       if (node.content.children) traverseArray(node.content.children, node);
+      traverseNode(node.content, node);
     }
     // Take care of template conditions
     if (node.branches) {

--- a/packages/cli/test/fixtures/vuejs.vue
+++ b/packages/cli/test/fixtures/vuejs.vue
@@ -23,6 +23,10 @@
       </div>
       <span>{{ t(`Text 9 with siblings`) }}<sup>*</sup></span>
       <SomeComponent :aprop="t('A prop string')"/>
+      <p>
+        Try out <a href="some" target="string">simple dom</a> doesn't break
+          things
+      </p>
   </div>
 </template>
 <script>


### PR DESCRIPTION
In a previous commit we included in the Vue parser the type `12` in visitors in order to parse some
simblings and pass the content to the BabelParser.

This resulted to simple text being parsed and Babel throwing an error when trying to parse for strings.

In this fix in case there are no `children` we use `traverseNode` to the `content` which should result to parsing all the things needed and causing no errors.