### PR TITLE
Better Vue props handling

### DIFF
--- a/packages/cli/src/api/parsers/vue.js
+++ b/packages/cli/src/api/parsers/vue.js
@@ -142,7 +142,11 @@ function extractVuePhrases(HASHES, source, relativeFile, options) {
 
     traverseVueTemplateAst(template.ast, {
       PropsExpression(node) {
-        babelExtractPhrases(HASHES, node.exp.loc.source, relativeFile, options);
+        // Complex props might cause unrelated errors in Babel
+        try {
+          babelExtractPhrases(HASHES, node.exp.loc.source, relativeFile, options);
+        // eslint-disable-next-line no-empty
+        } catch (e) {}
       },
       Expression(node) {
         babelExtractPhrases(HASHES, node.content.loc.source, relativeFile, options);

--- a/packages/cli/test/fixtures/vuejs.vue
+++ b/packages/cli/test/fixtures/vuejs.vue
@@ -27,6 +27,12 @@
         Try out <a href="some" target="string">simple dom</a> doesn't break
           things
       </p>
+      <Comp :to="{
+        aprop: `${avariable}`,
+        anotherprop: {
+          something: 'something',
+        }}"
+      />
   </div>
 </template>
 <script>


### PR DESCRIPTION
Some complex props were causing errors in
`babelExtractPhrases`. For now these are silenced
so the parsing can continue without any issues.