### PR TITLE
Implement Types for native

### DIFF
--- a/packages/angular/projects/tx-native-angular-sdk/src/lib/interfaces.ts
+++ b/packages/angular/projects/tx-native-angular-sdk/src/lib/interfaces.ts
@@ -15,6 +15,7 @@ export interface ILanguage {
   code: string;
   name: string;
   localized_name: string;
+  rtl?: boolean;
 }
 
 export interface ITranslateParams {

--- a/packages/angular/projects/tx-native-angular-sdk/tests/language-picker.component.spec.ts
+++ b/packages/angular/projects/tx-native-angular-sdk/tests/language-picker.component.spec.ts
@@ -22,8 +22,8 @@ describe('LanguagePickerComponent', () => {
     sanitize: false,
   };
   const languages: ILanguage[] = [
-    { code: 'en', name: 'English', localized_name: 'English' },
-    { code: 'el', name: 'Greek', localized_name: 'Ελληνικά' },
+    { code: 'en', name: 'English', localized_name: 'English', rtl: false },
+    { code: 'el', name: 'Greek', localized_name: 'Ελληνικά', rtl: false },
   ];
 
   beforeEach(async () => {
@@ -48,7 +48,7 @@ describe('LanguagePickerComponent', () => {
 
   it('should get languages', async () => {
     // setup
-    spyOn(service, 'getLanguages').and.returnValue(Promise.resolve(languages));
+    spyOn(service, 'getLanguages').and.resolveTo(languages);
 
     // act
     await component.getLanguages();
@@ -60,7 +60,7 @@ describe('LanguagePickerComponent', () => {
 
   it('should show a select component with languages', async () => {
     // setup
-    spyOn(service, 'getLanguages').and.returnValue(Promise.resolve(languages));
+    spyOn(service, 'getLanguages').and.resolveTo(languages);
 
     // act
     await component.ngOnInit();
@@ -76,7 +76,7 @@ describe('LanguagePickerComponent', () => {
 
   it('should detect language change', async () => {
     // setup
-    spyOn(service, 'getLanguages').and.returnValue(Promise.resolve(languages));
+    spyOn(service, 'getLanguages').and.resolveTo(languages);
     spyOn(service, 'setCurrentLocale').and.returnValue(Promise.resolve());
     spyOn(component, 'onChange').and.callThrough();
 
@@ -104,7 +104,7 @@ describe('LanguagePickerComponent', () => {
     component.instance = instance;
     const instanceReadySpy = spyOnProperty(component, 'instanceReady', 'get')
       .and.returnValue(of(true));
-    spyOn(service, 'getLanguages').and.returnValue(Promise.resolve(languages));
+    spyOn(service, 'getLanguages').and.resolveTo(languages);
 
     // act
     await instance.ngOnInit();

--- a/packages/angular/projects/tx-native-angular-sdk/tests/translation.service.spec.ts
+++ b/packages/angular/projects/tx-native-angular-sdk/tests/translation.service.spec.ts
@@ -1,21 +1,23 @@
 import { not } from '@angular/compiler/src/output/output_ast';
 import { TestBed } from '@angular/core/testing';
-import { tx } from '@transifex/native';
+import { tx, ILanguage, ITranslationConfig } from '@transifex/native';
 
 import { TranslationService } from '../src/lib/translation.service';
-import { ILanguage, ITranslationServiceConfig } from '../src/public-api';
+import { ITranslationServiceConfig } from '../src/public-api';
 
 describe('TranslationService', () => {
   let service: TranslationService;
   const txConfig: ITranslationServiceConfig = {
     token: '',
-    cache: () => { },
     cdsHost: '',
-    errorPolicy: undefined,
     filterTags: '',
     filterStatus: '',
-    missingPolicy: undefined,
-    stringRenderer: undefined,
+  };
+  const txTranslationConfig: ITranslationConfig = {
+    token: '',
+    cdsHost: '',
+    filterTags: '',
+    filterStatus: '',
   };
   const translationParams = {
     _key: '',
@@ -28,8 +30,8 @@ describe('TranslationService', () => {
     sanitize: false,
   };
   const languages: ILanguage[] = [
-    { code: 'en', name: 'English', localized_name: 'English' },
-    { code: 'el', name: 'Greek', localized_name: 'Ελληνικά' },
+    { code: 'en', name: 'English', localized_name: 'English', rtl: false },
+    { code: 'el', name: 'Greek', localized_name: 'Ελληνικά', rtl: false },
   ];
 
   beforeEach(() => {
@@ -60,7 +62,7 @@ describe('TranslationService', () => {
     // assert
     expect(service).toBeTruthy();
     expect(tx.init).toHaveBeenCalledWith(
-      { ...txConfig },
+      { ...txTranslationConfig },
     );
   });
 
@@ -136,7 +138,7 @@ describe('TranslationService', () => {
 
   it('should get languages', async () => {
     // setup
-    spyOn(tx, 'getLanguages').and.returnValue(Promise.resolve(languages));
+    spyOn(tx, 'getLanguages').and.resolveTo(languages);
 
     // act
     const result = await service.getLanguages();
@@ -148,7 +150,7 @@ describe('TranslationService', () => {
 
   it('should add a controlled instance successfully', async () => {
     // setup
-    spyOn(tx, 'controllerOf').and.returnValue({});
+    spyOn(tx, 'controllerOf').and.resolveTo();
 
     const instanceConfig = {
       token: 'token',
@@ -166,7 +168,7 @@ describe('TranslationService', () => {
 
   it('should add a not controlled instance successfully', async () => {
     // setup
-    spyOn(tx, 'controllerOf').and.returnValue({});
+    spyOn(tx, 'controllerOf').and.resolveTo();
 
     const instanceConfig = {
       token: 'token',
@@ -184,7 +186,7 @@ describe('TranslationService', () => {
 
   it('should not add a malformed instance (alias)', async () => {
     // setup
-    spyOn(tx, 'controllerOf').and.returnValue({});
+    spyOn(tx, 'controllerOf').and.resolveTo();
 
     const instanceConfig = {
       token: 'token',
@@ -200,7 +202,7 @@ describe('TranslationService', () => {
 
   it('should not add a malformed instance (token)', async () => {
     // setup
-    spyOn(tx, 'controllerOf').and.returnValue({});
+    spyOn(tx, 'controllerOf').and.resolveTo();
 
     const instanceConfig = {
       token: '',
@@ -222,7 +224,7 @@ describe('TranslationService', () => {
       controlled: false,
     };
     await service.addInstance(instanceConfig);
-    spyOn(tx, 'controllerOf').and.returnValue({});
+    spyOn(tx, 'controllerOf').and.resolveTo();
 
     // act
     const result = await service.addInstance(instanceConfig);
@@ -252,9 +254,7 @@ describe('TranslationService', () => {
 
   it('should fetch translations on demand without custom instance', async () => {
     // setup
-    spyOn(tx, 'fetchTranslations').and.returnValue(
-      Promise.resolve({}),
-    );
+    spyOn(tx, 'fetchTranslations').and.resolveTo();
     spyOn(service, 'getInstance').and.returnValue(
       {
         currentLocale: 'en',
@@ -276,9 +276,7 @@ describe('TranslationService', () => {
   it('should fetch translations on demand without custom instance no fetched tags',
     async () => {
       // setup
-      spyOn(tx, 'fetchTranslations').and.returnValue(
-        Promise.resolve({}),
-      );
+      spyOn(tx, 'fetchTranslations').and.resolveTo();
       spyOn(service, 'getInstance').and.returnValue(
         {
           currentLocale: 'en',
@@ -299,9 +297,7 @@ describe('TranslationService', () => {
 
   it('should fetch translations on demand with custom instance', async () => {
     // setup
-    spyOn(tx, 'fetchTranslations').and.returnValue(
-      Promise.resolve({}),
-    );
+    spyOn(tx, 'fetchTranslations').and.resolveTo();
     spyOn(service, 'getInstance').and.returnValue(
       {
         currentLocale: 'en',
@@ -323,9 +319,7 @@ describe('TranslationService', () => {
 
   it('should not fetch translations on demand if no instance', async () => {
     // setup
-    spyOn(tx, 'fetchTranslations').and.returnValue(
-      Promise.resolve({}),
-    );
+    spyOn(tx, 'fetchTranslations').and.resolveTo();
 
     // act
     await service.fetchTranslations('tag1');

--- a/packages/native/src/index.d.ts
+++ b/packages/native/src/index.d.ts
@@ -9,7 +9,7 @@ declare module '@transifex/native' {
     _tags?: string;
   }
 
-  export interface ITranslationServiceConfig {
+  export interface ITranslationConfig {
     cache?: IMemoryCache;
     cdsHost?: string;
     currentLocale?: string;
@@ -53,7 +53,7 @@ declare module '@transifex/native' {
     handle(error: Error, sourceString: string, localeCode: string, params: ITranslateParams): string;
   }
 
-  export class TxNative implements ITranslationServiceConfig {
+  export class TxNative implements ITranslationConfig {
     cache: IMemoryCache;
     cdsHost: string;
     childInstances: TxNative[];
@@ -81,7 +81,7 @@ declare module '@transifex/native' {
 
     getLocales(config?: { refresh?: boolean }): Promise<string[]>;
 
-    init(config: ITranslationServiceConfig): void;
+    init(config: ITranslationConfig): void;
 
     invalidateCDS(config?: { purge?: boolean }): Promise<{ count: number; status: number; token: number }>;
 
@@ -165,7 +165,7 @@ declare module '@transifex/native' {
     localeCode: string;
   }
 
-  export function createNativeInstance(initOptions: ITranslationServiceConfig): TxNative;
+  export function createNativeInstance(initOptions: ITranslationConfig): TxNative;
 
   export function escape(unsafe: string): string;
 

--- a/packages/native/src/index.d.ts
+++ b/packages/native/src/index.d.ts
@@ -1,13 +1,12 @@
 declare module '@transifex/native' {
   export interface ITranslateParams {
+    [key: string]: unknown;
     _charlimit?: number;
     _comment?: string;
     _context?: string;
     _escapeVars?: boolean;
-    _inline?: boolean;
     _key?: string;
     _tags?: string;
-    sanitize?: boolean;
   }
 
   export interface ITranslationServiceConfig {

--- a/packages/native/src/index.d.ts
+++ b/packages/native/src/index.d.ts
@@ -1,32 +1,198 @@
 declare module '@transifex/native' {
-  export const tx: any;
-  export const t: any;
-  export const PseudoTranslationPolicy: any;
-  export const SourceStringPolicy: any;
-  export const SourceErrorPolicy: any;
-  export const ThrowErrorPolicy: any;
-  export const MessageFormatRenderer: any;
-  export const createNativeInstance: any;
+  export interface ITranslateParams {
+    _charlimit?: number;
+    _comment?: string;
+    _context?: string;
+    _escapeVars?: boolean;
+    _inline?: boolean;
+    _key?: string;
+    _tags?: string;
+    sanitize?: boolean;
+  }
 
-  // Events
+  export interface ITranslationServiceConfig {
+    cache?: IMemoryCache;
+    cdsHost?: string;
+    currentLocale?: string;
+    errorPolicy?: IErrorPolicy;
+    fetchInterval?: number;
+    fetchTimeout?: number;
+    filterStatus?: string;
+    filterTags?: string;
+    missingPolicy?: ITranslationPolicy;
+    secret?: string;
+    stringRenderer?: IMessageFormatRenderer;
+    token?: string;
+  }
+
+  type Plurals = [string, Record<string, string>];
+
+  interface ILanguage {
+    code: string;
+    localized_name: string;
+    name: string;
+    rtl: boolean;
+  }
+
+  interface IMemoryCache {
+    get(key: string, localeCode: string): Record<string, string>;
+    getTranslations(localeCode: string): Record<string, string>;
+    hasTranslations(localeCode: string): boolean;
+    isStale(localeCode: string): boolean;
+    update(localeCode: string, translations: Record<string, string>): void;
+  }
+
+  interface IMessageFormatRenderer {
+    render(sourceString: string, localeCode: string, params: ITranslateParams): string;
+  }
+
+  interface ITranslationPolicy {
+    handle(sourceString: string, localeCode: string): string;
+  }
+
+  interface IErrorPolicy {
+    handle(error: Error, sourceString: string, localeCode: string, params: ITranslateParams): string;
+  }
+
+  export class TxNative implements ITranslationServiceConfig {
+    cache: IMemoryCache;
+    cdsHost: string;
+    childInstances: TxNative[];
+    currentLocale: string;
+    errorPolicy: IErrorPolicy;
+    fetchedTags?: Record<string, string[]>;
+    fetchInterval: number;
+    fetchTimeout: number;
+    filterStatus: string;
+    filterTags: string;
+    languages: ILanguage[];
+    locales: string[];
+    missingPolicy: ITranslationPolicy;
+    secret: string;
+    stringRenderer: IMessageFormatRenderer;
+    token: string;
+
+    controllerOf(instance: TxNative): Promise<TxNative>;
+
+    fetchTranslations(localeCode: string, config?: { filterTags?: string; refresh?: boolean }): Promise<void>;
+
+    getCurrentLocale(): string;
+
+    getLanguages(config?: { refresh?: boolean }): Promise<ILanguage[]>;
+
+    getLocales(config?: { refresh?: boolean }): Promise<string[]>;
+
+    init(config: ITranslationServiceConfig): void;
+
+    invalidateCDS(config?: { purge?: boolean }): Promise<{ count: number; status: number; token: number }>;
+
+    isCurrent(localeCode: string): boolean;
+
+    pushSource(
+      payload: Record<string, {
+        meta: {
+          character_limit: number;
+          context: string;
+          developer_comment: string;
+          occurrences: string[];
+          tags: string[];
+        };
+        string: string;
+      }>,
+      config?: { noWait: boolean; overrideTags: boolean; purge: boolean }
+    ): Promise<{
+      created: number;
+      deleted: number;
+      errors: string[];
+      failed: number;
+      jobUrl: string;
+      skipped: number;
+      status: string;
+      updated: number;
+    }>;
+
+    setCurrentLocale(localeCode: string): Promise<void>;
+
+    translate(sourceString: string, params?: ITranslateParams): string;
+
+    translateLocale(localeCode: string, sourceString: string, params?: ITranslateParams): string;
+  }
+
+  export class MessageFormatRenderer implements IMessageFormatRenderer {
+    render(sourceString: string, localeCode: string, params: ITranslateParams): string;
+  }
+
+  export class PseudoTranslationPolicy implements ITranslationPolicy {
+    handle(sourceString: string, _localeCode: string): string;
+  }
+
+  export class SourceErrorPolicy implements IErrorPolicy {
+    handle(_error: Error, sourceString: string, _localeCode: string, _params: ITranslateParams): string;
+  }
+
+  export class SourceStringPolicy implements ITranslationPolicy {
+    handle(sourceString: string, _localeCode: string): string;
+  }
+
+  export class ThrowErrorPolicy implements IErrorPolicy {
+    handle(error: Error, sourceString: string, _localeCode: string, _params: ITranslateParams): never;
+  }
+
   export const FETCHING_TRANSLATIONS = 'FETCHING_TRANSLATIONS';
-  export const TRANSLATIONS_FETCHED = 'TRANSLATIONS_FETCHED';
-  export const TRANSLATIONS_FETCH_FAILED = 'TRANSLATIONS_FETCH_FAILED';
-  export const LOCALE_CHANGED = 'LOCALE_CHANGED';
-  export const FETCHING_LOCALES = 'FETCHING_LOCALES';
-  export const LOCALES_FETCHED = 'LOCALES_FETCHED';
-  export const LOCALES_FETCH_FAILED = 'LOCALES_FETCH_FAILED';
-  export const onEvent: any;
-  export const offEvent: any;
-  export const sendEvent: any;
 
-  // Utils
-  export const escape: any;
-  export const isString: any;
-  export const generateHashedKey: any;
-  export const generateKey: any;
-  export const isPluralized: any;
-  export const explodePlurals: any;
-  export const implodePlurals: any;
-  export const normalizeLocale: any;
+  export const TRANSLATIONS_FETCHED = 'TRANSLATIONS_FETCHED';
+
+  export const TRANSLATIONS_FETCH_FAILED = 'TRANSLATIONS_FETCH_FAILED';
+
+  export const LOCALE_CHANGED = 'LOCALE_CHANGED';
+
+  export const FETCHING_LOCALES = 'FETCHING_LOCALES';
+
+  export const LOCALES_FETCHED = 'LOCALES_FETCHED';
+
+  export const LOCALES_FETCH_FAILED = 'LOCALES_FETCH_FAILED';
+
+  type EventTypes =
+    | typeof FETCHING_LOCALES
+    | typeof FETCHING_TRANSLATIONS
+    | typeof LOCALE_CHANGED
+    | typeof LOCALES_FETCH_FAILED
+    | typeof LOCALES_FETCHED
+    | typeof TRANSLATIONS_FETCH_FAILED
+    | typeof TRANSLATIONS_FETCHED;
+
+  interface EventPayload {
+    filterTags: string;
+    localeCode: string;
+  }
+
+  export function createNativeInstance(initOptions: ITranslationServiceConfig): TxNative;
+
+  export function escape(unsafe: string): string;
+
+  export function explodePlurals(str: string): Plurals;
+
+  export function generateHashedKey(str: string, options?: { _context?: string; _key?: string }): string;
+
+  export function generateKey(str: string, options?: { _context?: string; _key?: string }): string;
+
+  export function implodePlurals(plurals: Plurals, count: string): string;
+
+  export function isPluralized(str: string): boolean;
+
+  export function isString(obj: unknown): boolean;
+
+  export function normalizeLocale(locale: string): string;
+
+  export function offEvent(eventType: EventTypes, fn: (payload: EventPayload | null, caller: TxNative) => void): void;
+
+  export function onEvent(eventType: EventTypes, fn: (payload: EventPayload | null, caller: TxNative) => void): void;
+
+  export function sendEvent(eventType: EventTypes, payload: EventPayload | null, caller: TxNative): void;
+
+  export function sleep(msec: number): Promise<void>;
+
+  export function t(str: string, params?: ITranslateParams): string;
+
+  export const tx: TxNative;
 }


### PR DESCRIPTION
Bad types like `any` are so much worse than no types at all. But at least this would be correct types (mostly). #64