### PR TITLE
jsonapi: Better handle plural relationships

### DIFF
--- a/packages/jsonapi/src/apis.js
+++ b/packages/jsonapi/src/apis.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'; /* eslint-disable-line max-classes-per-file */
 import axios from 'axios';
 
-import { isNull, isResource } from './utils';
+import { isResource } from './utils';
 import { JsonApiException } from './errors';
 import Resource from './resources';
 
@@ -25,7 +25,7 @@ export function validateStatus(status) {
   *
   *   const familyApi = new FamilyApi({ auth: 'MYTOKEN' });
   *
-  * After this, you can access the `Resouce` subclass and its methods on the
+  * After this, you can access the `Resource` subclass and its methods on the
   * connection instance directly. You can use either the name you supplied as a
   * second argument to `.register()` or its TYPE static field:
   *
@@ -190,7 +190,7 @@ export default class JsonApi {
     * Appropriate Resource subclass.
     * */
   asResource(value) {
-    if (isNull(value) || isResource(value)) {
+    if (!value || isResource(value)) {
       return value;
     }
     let actualValue = value;

--- a/packages/jsonapi/src/collections.js
+++ b/packages/jsonapi/src/collections.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 
 import { DoesNotExist, MultipleObjectsReturned } from './errors';
-import { hasData, isNull } from './utils'; /* eslint-disable-line import/no-cycle */
+import { hasData } from './utils'; /* eslint-disable-line import/no-cycle */
 import Resource from './resources'; /* eslint-disable-line import/no-cycle */
 
 /**
@@ -45,7 +45,7 @@ export default class Collection {
   }
 
   async fetch() {
-    if (!isNull(this.data)) {
+    if (this.data) {
       return;
     }
 
@@ -69,7 +69,7 @@ export default class Collection {
       Object
         .entries(item.relationships || {})
         .forEach(([name, relationship]) => {
-          if (isNull(relationship) || !hasData(relationship)) {
+          if (!relationship || !hasData(relationship)) {
             return;
           }
           const key = `${relationship.data.type}__${relationship.data.id}`;

--- a/packages/jsonapi/src/utils.js
+++ b/packages/jsonapi/src/utils.js
@@ -4,40 +4,31 @@ import Collection from './collections'; /* eslint-disable-line import/no-cycle *
 import Resource from './resources'; /* eslint-disable-line import/no-cycle */
 
 export function hasData(value) {
-  return _.isObject(value) && 'data' in value;
+  return _.isPlainObject(value) && 'data' in value;
 }
 
 export function hasLinks(value) {
-  return _.isObject(value) && 'links' in value;
-}
-
-export function isNull(value) {
-  return !value;
-}
-
-export function isSingularFetched(value) {
-  return (!isNull(value)
-          && value instanceof Resource
-          && (_.size(value.attributes) > 0 || _.size(value.relationships) > 0));
-}
-
-export function isPluralFetched(value) {
-  return (!isNull(value)
-          && value instanceof Collection);
-}
-
-export function isList(value) {
-  return _.isArray(value);
-}
-
-export function isObject(value) {
-  return _.isPlainObject(value);
+  return _.isPlainObject(value) && 'links' in value;
 }
 
 export function isResource(value) {
   return value instanceof Resource;
 }
 
+export function isSingularFetched(value) {
+  return (value
+          && isResource(value)
+          && (_.size(value.attributes) > 0 || _.size(value.relationships) > 0));
+}
+
+export function isPluralFetched(value) {
+  return value && value instanceof Collection;
+}
+
+export function isCollection(value) {
+  return value instanceof Collection;
+}
+
 export function isResourceIdentifier(value) {
-  return _.isObject(value) && 'type' in value && 'id' in value;
+  return _.isPlainObject(value) && 'type' in value && 'id' in value;
 }

--- a/packages/jsonapi/tests/resources.spec.js
+++ b/packages/jsonapi/tests/resources.spec.js
@@ -412,6 +412,81 @@ test('save new', async () => {
   });
 });
 
+test('save new with plural relationship', async () => {
+  const parent = new api.Parent({
+    name: 'Bill',
+    children: [new api.Child({ id: '1' }), new api.Child({ id: '2' })],
+  });
+  axios.request.mockResolvedValue({
+    method: 'post',
+    url: '/parents',
+    data: {
+      data: {
+        type: 'parents',
+        id: '1',
+        attributes: { name: 'Bill', created: 'now' },
+        relationships: {
+          children: { links: { related: '/parents/1/children' } },
+        },
+      },
+    },
+  });
+  await parent.save();
+  expectRequestMock({
+    url: '/parents',
+    method: 'post',
+    data: {
+      data: {
+        type: 'parents',
+        attributes: { name: 'Bill' },
+        relationships: {
+          children: {
+            data: [{ type: 'children', id: '1' }, { type: 'children', id: '2' }],
+          },
+        },
+      },
+    },
+  });
+  expect(parent).toEqual({
+    id: '1',
+    attributes: { name: 'Bill', created: 'now' },
+    links: {},
+    redirect: null,
+    relationships: {
+      children: {
+        data: [{ type: 'children', id: '1' }, { type: 'children', id: '2' }],
+      },
+    },
+    related: {
+      children: {
+        _API: api,
+        _url: null,
+        _params: null,
+        data: [
+          {
+            id: '1',
+            attributes: {},
+            links: {},
+            redirect: null,
+            relationships: {},
+            related: {},
+          },
+          {
+            id: '2',
+            attributes: {},
+            links: {},
+            redirect: null,
+            relationships: {},
+            related: {},
+          },
+        ],
+        next: null,
+        previous: null,
+      },
+    },
+  });
+});
+
 test('create', async () => {
   axios.request.mockResolvedValue({
     data: {
@@ -434,6 +509,80 @@ test('create', async () => {
     redirect: null,
     relationships: {},
     related: {},
+  });
+});
+
+test('create with plural relationship', async () => {
+  axios.request.mockResolvedValue({
+    method: 'post',
+    url: '/parents',
+    data: {
+      data: {
+        type: 'parents',
+        id: '1',
+        attributes: { name: 'Bill', created: 'now' },
+        relationships: {
+          children: { links: { related: '/parents/1/children' } },
+        },
+      },
+    },
+  });
+  const parent = await api.Parent.create({
+    name: 'Bill',
+    children: [new api.Child({ id: '1' }), new api.Child({ id: '2' })],
+  });
+  expectRequestMock({
+    url: '/parents',
+    method: 'post',
+    data: {
+      data: {
+        type: 'parents',
+        attributes: { name: 'Bill' },
+        relationships: {
+          children: {
+            data: [{ type: 'children', id: '1' }, { type: 'children', id: '2' }],
+          },
+        },
+      },
+    },
+  });
+  expect(parent).toEqual({
+    id: '1',
+    attributes: { name: 'Bill', created: 'now' },
+    links: {},
+    redirect: null,
+    relationships: {
+      children: {
+        data: [{ type: 'children', id: '1' }, { type: 'children', id: '2' }],
+      },
+    },
+    related: {
+      children: {
+        _API: api,
+        _url: null,
+        _params: null,
+        data: [
+          {
+            id: '1',
+            attributes: {},
+            links: {},
+            redirect: null,
+            relationships: {},
+            related: {},
+          },
+          {
+            id: '2',
+            attributes: {},
+            links: {},
+            redirect: null,
+            relationships: {},
+            related: {},
+          },
+        ],
+        next: null,
+        previous: null,
+      },
+    },
   });
 });
 


### PR DESCRIPTION
When the user supplied a list of related objects of a plural relationship during initialization, the library had some bugs. These weren't discovered until now because we don't work with plural relationships like this in Transifex APIv3