### PR TITLE
Fix for relative path on verbose output in CLI

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,8 +35,7 @@
     "ejs": "^3.1.8",
     "glob": "^8.0.3",
     "lodash": "^4.17.21",
-    "pug": "^3.0.2",
-    "shelljs": "^0.8.5"
+    "pug": "^3.0.2"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.26.10",

--- a/packages/cli/src/commands/push.js
+++ b/packages/cli/src/commands/push.js
@@ -6,7 +6,6 @@ const fs = require('fs');
 const path = require('path');
 const _ = require('lodash');
 const { Command, Flags } = require('@oclif/core');
-const shelljs = require('shelljs');
 const { glob } = require('glob');
 const { CliUx } = require('@oclif/core');
 const { extractPhrases } = require('../api/extract');
@@ -32,7 +31,7 @@ function isFolder(path) {
 class PushCommand extends Command {
   async run() {
     const { args, flags } = await this.parse(PushCommand);
-    const pwd = `${shelljs.pwd()}`;
+    const pwd = path.resolve(process.cwd());
     let filePattern = path.isAbsolute(args.pattern)
       ? args.pattern
       : path.join(pwd, args.pattern);
@@ -78,7 +77,7 @@ class PushCommand extends Command {
     };
 
     _.each(allFiles, (file) => {
-      const relativeFile = path.relative(process.cwd(), file);
+      const relativeFile = path.relative(pwd, file);
       bar.increment({ file: relativeFile.gray });
       try {
         const data = extractPhrases(file, relativeFile, extractOptions);

--- a/packages/cli/src/commands/push.js
+++ b/packages/cli/src/commands/push.js
@@ -78,7 +78,7 @@ class PushCommand extends Command {
     };
 
     _.each(allFiles, (file) => {
-      const relativeFile = file.replace(pwd, '');
+      const relativeFile = path.relative(process.cwd(), file);
       bar.increment({ file: relativeFile.gray });
       try {
         const data = extractPhrases(file, relativeFile, extractOptions);

--- a/packages/cli/test/commands/push.test.js
+++ b/packages/cli/test/commands/push.test.js
@@ -18,7 +18,7 @@ describe('push command', () => {
       expect(ctx.stdout).to.contain('5d47152bcd597dd6adbff4884374aaad: Text 2');
       expect(ctx.stdout).to.contain('3cd62915590816fdbf53852e44ee675a: Text 3');
       expect(ctx.stdout).to.contain('33f5afa925f1464280d72d6d9086057c: Text 4');
-      expect(ctx.stdout).to.contain('occurrences: ["/test/fixtures/simple.js"]');
+      expect(ctx.stdout).to.contain('occurrences: ["test/fixtures/simple.js"]');
     });
 
   test
@@ -29,7 +29,7 @@ describe('push command', () => {
       expect(ctx.stdout).to.contain('Text 2');
       expect(ctx.stdout).to.contain('Text 3');
       expect(ctx.stdout).to.contain('Text 4');
-      expect(ctx.stdout).to.contain('occurrences: ["/test/fixtures/simple.js"]');
+      expect(ctx.stdout).to.contain('occurrences: ["test/fixtures/simple.js"]');
     });
 
   test


### PR DESCRIPTION
This change show the relative path (related to the CLI execution) instead of full path.