### PR TITLE
@transifex/cli: Add params for deleting translations & tags

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -103,7 +103,7 @@ detect and push source content to Transifex
 ```
 USAGE
   $ txjs-cli push [PATTERN] [--dry-run] [--fake] [-v] [--purge] [--no-wait] [--token <value>] [--secret <value>] [--append-tags <value>] [--with-tags-only <value>] [--without-tags-only <value>]
-    [--cds-host <value>] [--parser auto|i18next|txnativejson] [--key-generator source|hash]
+    [--cds-host <value>] [--do-not-keep-translations] [--override-tags] [--parser auto|i18next|txnativejson] [--key-generator source|hash]
 
 ARGUMENTS
   PATTERN  [default: **/*.{js,jsx,ts,tsx,html,vue,pug,ejs}] file pattern to scan for strings
@@ -112,11 +112,13 @@ FLAGS
   -v, --verbose                verbose output
   --append-tags=<value>        append tags to strings
   --cds-host=<value>           CDS host URL
+  --do-not-keep-translations   remove translations when source strings change
   --dry-run                    dry run, do not apply changes in Transifex
   --fake                       do not push content to remote server
   --key-generator=<option>     [default: source] use hashed or source based keys
                                <options: source|hash>
   --no-wait                    disable polling for upload results
+  --override-tags              override tags when pushing content
   --parser=<option>            [default: auto] file parser to use
                                <options: auto|i18next|txnativejson>
   --purge                      purge content on Transifex

--- a/packages/cli/src/api/upload.js
+++ b/packages/cli/src/api/upload.js
@@ -19,6 +19,8 @@ async function uploadPhrases(payload, params) {
     meta: {
       purge: !!params.purge,
       dry_run: !!params.dry_run,
+      keep_translations: !params.do_not_keep_translations,
+      override_tags: !!params.override_tags,
     },
   }, {
     headers: {

--- a/packages/cli/src/commands/push.js
+++ b/packages/cli/src/commands/push.js
@@ -168,6 +168,8 @@ class PushCommand extends Command {
           token: projectToken,
           secret: projectSecret,
           purge: flags.purge,
+          do_not_keep_translations: flags['do-not-keep-translations'],
+          override_tags: flags['override-tags'],
           dry_run: flags['dry-run'],
         });
 
@@ -317,6 +319,14 @@ PushCommand.flags = {
   'cds-host': Flags.string({
     description: 'CDS host URL',
     default: '',
+  }),
+  'do-not-keep-translations': Flags.boolean({
+    description: 'remove translations when source strings change',
+    default: false,
+  }),
+  'override-tags': Flags.boolean({
+    description: 'override tags when pushing content',
+    default: false,
   }),
   parser: Flags.string({
     description: 'file parser to use',


### PR DESCRIPTION
Update `txjs-cli push` with two additional parameters:
* `--do-not-keep-translations`: Remove translations in Transifex when the source string for an existing key changes.
* `--override-tags`: Replace all tags of strings in Transifex with the ones pushed using the CLI.