### PR TITLE
Update globalObject webpack target

### DIFF
--- a/packages/api/webpack.config.js
+++ b/packages/api/webpack.config.js
@@ -5,6 +5,7 @@ module.exports = [
     mode: 'production',
     entry: './src/transifexApi.js',
     output: {
+      globalObject: 'this',
       path: path.resolve(__dirname, 'dist'),
       filename: 'node.transifexApi.js',
       library: 'transifexApi',
@@ -17,6 +18,7 @@ module.exports = [
     mode: 'production',
     entry: './src/transifexApi.js',
     output: {
+      globalObject: 'this',
       path: path.resolve(__dirname, 'dist'),
       filename: 'browser.transifexApi.js',
       library: 'transifexApi',

--- a/packages/dom/webpack.browser.js
+++ b/packages/dom/webpack.browser.js
@@ -6,6 +6,7 @@ module.exports = {
   mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
   entry: './src/index.js',
   output: {
+    globalObject: 'this',
     path: path.resolve(__dirname, 'dist'),
     filename: 'browser.dom.js',
     library: 'TransifexDOM',

--- a/packages/dom/webpack.node.js
+++ b/packages/dom/webpack.node.js
@@ -6,6 +6,7 @@ module.exports = {
   mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
   entry: './src/index.js',
   output: {
+    globalObject: 'this',
     path: path.resolve(__dirname, 'dist'),
     filename: 'node.dom.js',
     library: 'transifexDOM',

--- a/packages/i18next/webpack.browser.js
+++ b/packages/i18next/webpack.browser.js
@@ -6,6 +6,7 @@ module.exports = {
   mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
   entry: './src/index.js',
   output: {
+    globalObject: 'this',
     path: path.resolve(__dirname, 'dist'),
     filename: 'browser.i18next.js',
     library: 'TxNativeI18next',

--- a/packages/i18next/webpack.node.js
+++ b/packages/i18next/webpack.node.js
@@ -6,6 +6,7 @@ module.exports = {
   mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
   entry: './src/index.js',
   output: {
+    globalObject: 'this',
     path: path.resolve(__dirname, 'dist'),
     filename: 'node.i18next.js',
     library: 'transifexI18next',

--- a/packages/jsonapi/webpack.config.js
+++ b/packages/jsonapi/webpack.config.js
@@ -5,6 +5,7 @@ module.exports = [
     mode: 'production',
     entry: './src/index.js',
     output: {
+      globalObject: 'this',
       path: path.resolve(__dirname, 'dist'),
       filename: 'node.jsonapi.js',
       library: 'jsonapi',
@@ -17,6 +18,7 @@ module.exports = [
     mode: 'production',
     entry: './src/index.js',
     output: {
+      globalObject: 'this',
       path: path.resolve(__dirname, 'dist'),
       filename: 'browser.jsonapi.js',
       library: 'jsonapi',

--- a/packages/native/webpack.browser.js
+++ b/packages/native/webpack.browser.js
@@ -6,6 +6,7 @@ module.exports = {
   mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
   entry: './src/index.js',
   output: {
+    globalObject: 'this',
     path: path.resolve(__dirname, 'dist'),
     filename: 'browser.native.js',
     library: 'Transifex',

--- a/packages/native/webpack.node.js
+++ b/packages/native/webpack.node.js
@@ -6,6 +6,7 @@ module.exports = {
   mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
   entry: './src/index.js',
   output: {
+    globalObject: 'this',
     path: path.resolve(__dirname, 'dist'),
     filename: 'node.native.js',
     library: 'transifex',


### PR DESCRIPTION
Set the webpack config `globalObject` to `this` to allow universal builds for both web and node.

This potentially fixes an issue with SSR related builds:
`ReferenceError: self is not defined`

Related: https://webpack.js.org/configuration/output/#outputglobalobject
