### PR TITLE
CLI: Add override-occurences flag

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -103,7 +103,7 @@ detect and push source content to Transifex
 ```
 USAGE
   $ txjs-cli push [PATTERN] [--dry-run] [--fake] [-v] [--purge] [--no-wait] [--token <value>] [--secret <value>] [--append-tags <value>] [--with-tags-only <value>] [--without-tags-only <value>]
-    [--cds-host <value>] [--do-not-keep-translations] [--override-tags] [--parser auto|i18next|txnativejson] [--key-generator source|hash]
+    [--cds-host <value>] [--do-not-keep-translations] [--override-tags] [--override-occurrences] [--parser auto|i18next|txnativejson] [--key-generator source|hash]
 
 ARGUMENTS
   PATTERN  [default: **/*.{js,jsx,ts,tsx,html,vue,pug,ejs}] file pattern to scan for strings
@@ -118,6 +118,7 @@ FLAGS
   --key-generator=<option>     [default: source] use hashed or source based keys
                                <options: source|hash>
   --no-wait                    disable polling for upload results
+  --override-occurrences       override occurrences when pushing content
   --override-tags              override tags when pushing content
   --parser=<option>            [default: auto] file parser to use
                                <options: auto|i18next|txnativejson>

--- a/packages/cli/src/api/upload.js
+++ b/packages/cli/src/api/upload.js
@@ -21,6 +21,7 @@ async function uploadPhrases(payload, params) {
       dry_run: !!params.dry_run,
       keep_translations: !params.do_not_keep_translations,
       override_tags: !!params.override_tags,
+      override_occurrences: !!params.override_occurrences,
     },
   }, {
     headers: {

--- a/packages/cli/src/commands/push.js
+++ b/packages/cli/src/commands/push.js
@@ -170,6 +170,7 @@ class PushCommand extends Command {
           purge: flags.purge,
           do_not_keep_translations: flags['do-not-keep-translations'],
           override_tags: flags['override-tags'],
+          override_occurrences: flags['override-occurrences'],
           dry_run: flags['dry-run'],
         });
 
@@ -326,6 +327,10 @@ PushCommand.flags = {
   }),
   'override-tags': Flags.boolean({
     description: 'override tags when pushing content',
+    default: false,
+  }),
+  'override-occurrences': Flags.boolean({
+    description: 'override occurrences when pushing content',
     default: false,
   }),
   parser: Flags.string({

--- a/packages/native/README.md
+++ b/packages/native/README.md
@@ -317,6 +317,9 @@ params: Object({
   // Replace the existing string tags with the tags of this request
   overrideTags: Boolean,
 
+  // Replace the existing string occurrences with the occurrences of this request
+  overrideOccurrences: Boolean,
+
   // If true, when wait for processing to be complete before
   // resolving this promise
   noWait: Boolean,

--- a/packages/native/src/TxNative.js
+++ b/packages/native/src/TxNative.js
@@ -300,6 +300,7 @@ export default class TxNative {
    * @param {Object} params
    * @param {Boolean} params.purge
    * @param {Boolean} params.overrideTags
+   * @param {Boolean} params.overrideOccurrences
    * @param {Boolean} params.noWait - do not wait for upload results
    * @returns {Object} Data
    * @returns {String} Data.jobUrl
@@ -327,6 +328,7 @@ export default class TxNative {
       meta: {
         purge: !!params.purge,
         override_tags: !!params.overrideTags,
+        override_occurrences: !!params.overrideOccurrences,
       },
     }, {
       headers,

--- a/packages/native/src/index.d.ts
+++ b/packages/native/src/index.d.ts
@@ -98,7 +98,7 @@ declare module '@transifex/native' {
         };
         string: string;
       }>,
-      config?: { noWait: boolean; overrideTags: boolean; purge: boolean }
+      config?: { noWait: boolean; overrideTags: boolean; overrideOccurrences: boolean; purge: boolean }
     ): Promise<{
       created: number;
       deleted: number;


### PR DESCRIPTION
Add CDS 4.x.x support for override-occurrences when pushing strings in both the SDK and the CLI.