### PR TITLE
Add support for Angular 15 self-closing-tags inside txjs-cli push

### DIFF
--- a/packages/cli/src/api/parsers/angularHTML.js
+++ b/packages/cli/src/api/parsers/angularHTML.js
@@ -150,7 +150,7 @@ function parseHTMLTemplateFile(HASHES, filename, relativeFile, options) {
   }
 
   const data = fs.readFileSync(filename, 'utf8');
-  const { rootNodes, errors } = ngHtmlParser.parse(data);
+  const { rootNodes, errors } = ngHtmlParser.parse(data, { canSelfClose: true });
   if (errors.length) return;
 
   parseTemplateNode(rootNodes);

--- a/packages/cli/test/api/extract.hashedkeys.test.js
+++ b/packages/cli/test/api/extract.hashedkeys.test.js
@@ -443,6 +443,16 @@ describe('extractPhrases with hashed keys', () => {
           },
           string: '{var4}',
         },
+        'text.inside-self-closing-tag': {
+          meta: {
+            context: [],
+            occurrences: [
+              'angular-template.html',
+            ],
+            tags: [],
+          },
+          string: 'This is some text inside a self-closing tag',
+        },
       });
   });
 

--- a/packages/cli/test/api/extract.sourcekeys.test.js
+++ b/packages/cli/test/api/extract.sourcekeys.test.js
@@ -424,6 +424,16 @@ describe('extractPhrases with source keys', () => {
           },
           string: '{var4}',
         },
+        'text.inside-self-closing-tag': {
+          meta: {
+            context: [],
+            occurrences: [
+              'angular-template.html',
+            ],
+            tags: [],
+          },
+          string: 'This is some text inside a self-closing tag',
+        },
       });
   });
 

--- a/packages/cli/test/fixtures/angular-template.html
+++ b/packages/cli/test/fixtures/angular-template.html
@@ -98,4 +98,6 @@
     >
     Content 1
   </mat-tab>
+
+  <T str="This is some text inside a self-closing tag" key="text.inside-self-closing-tag" />
 </div>


### PR DESCRIPTION
Fixes issue inside `txjs-cli push` where an Angular template containing _any_ non-standard self-closing-tags causes the parser to silently fail and _no_ translation strings being picked up inside that template. More context in #193 

Closes #193 