### PR TITLE
Fix setup section parse in vue 3 files

### DIFF
--- a/packages/cli/src/api/parsers/vue.js
+++ b/packages/cli/src/api/parsers/vue.js
@@ -139,6 +139,12 @@ function extractVuePhrases(HASHES, source, relativeFile, options) {
       id: 'sfc-compiler',
       source: vueContent.descriptor.template.content,
     });
+    
+    // Get the vue setup Content from the file and extract hashes/phrases with Babel
+    if (vueContent.descriptor.scriptSetup && vueContent.descriptor.scriptSetup.content) {
+      const script = vueContent.descriptor.scriptSetup.content;
+      babelExtractPhrases(HASHES, script, relativeFile, options);
+    }
 
     traverseVueTemplateAst(template.ast, {
       PropsExpression(node) {


### PR DESCRIPTION
Parser doesn't identify vue3 setup script section. Add condition section which  check exist of `vueContent.descriptor.scriptSetup` and parse content. 