### PR TITLE
Remove defaultProps from React package

### DIFF
--- a/packages/react/src/components/LanguagePicker.jsx
+++ b/packages/react/src/components/LanguagePicker.jsx
@@ -10,7 +10,7 @@ import useTX from '../hooks/useTX';
   *
   * - className: the CSS class to use on the <select> tag */
 
-export default function LanguagePicker({ className }) {
+export default function LanguagePicker({ className = '' }) {
   const languages = useLanguages();
   const locale = useLocale();
   const tx = useTX();
@@ -30,8 +30,4 @@ export default function LanguagePicker({ className }) {
 
 LanguagePicker.propTypes = {
   className: PropTypes.string,
-};
-
-LanguagePicker.defaultProps = {
-  className: '',
 };

--- a/packages/react/src/components/T.jsx
+++ b/packages/react/src/components/T.jsx
@@ -25,6 +25,4 @@ export default function T({ _str, ...props }) {
   return useT()(_str, props);
 }
 
-T.defaultProps = {};
-
 T.propTypes = { _str: PropTypes.string.isRequired };

--- a/packages/react/src/components/UT.jsx
+++ b/packages/react/src/components/UT.jsx
@@ -18,7 +18,7 @@ import useT from '../hooks/useT';
  * `div` or a `span`.
  * */
 
-export default function UT({ _str, _inline, ...props }) {
+export default function UT({ _str, _inline = false, ...props }) {
   const translation = useT()(
     _str,
     { _inline, _escapeVars: true, ...props },
@@ -27,10 +27,6 @@ export default function UT({ _str, _inline, ...props }) {
   const parent = _inline ? 'span' : 'div';
   return React.createElement(parent, parentProps);
 }
-
-UT.defaultProps = {
-  _inline: false,
-};
 
 UT.propTypes = {
   _str: PropTypes.string.isRequired,


### PR DESCRIPTION
React 18.3 added a [deprecation warning ](https://github.com/facebook/react/blob/main/CHANGELOG.md#1830-april-25-2024)for usage of defaultProps in functional components.
This PR replaces its usage with Javascript's default parameters.

