### PR TITLE
Support CSP without unsafe-eval

### DIFF
--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -53,8 +53,8 @@
     "webpack-cli": "^5.1.4"
   },
   "dependencies": {
-    "@messageformat/core": "^3.3.0",
     "cross-fetch": "^4.0.0",
+    "intl-messageformat": "^10.5.14",
     "md5": "^2.3.0"
   }
 }

--- a/packages/native/src/renderers/MessageFormatRenderer.js
+++ b/packages/native/src/renderers/MessageFormatRenderer.js
@@ -1,9 +1,5 @@
 /* eslint-disable class-methods-use-this */
-import MessageFormat from '@messageformat/core';
-
-// object to cache MessageFormat classes related to
-// specific locales
-const MF = {};
+import IntlMessageFormat from 'intl-messageformat';
 
 /**
  * MessageFormat renderer
@@ -16,18 +12,12 @@ export default class MessageFormatRenderer {
     // construct a MessageFormat class based on locale
     // to make dates and other content localizable
     const locale = ((localeCode || '').split('_'))[0];
-    if (!MF[locale]) {
-      try {
-        MF[locale] = new MessageFormat(locale, {
-          strictPluralKeys: false,
-        });
-      } catch (err) {
-        MF[locale] = new MessageFormat('*', {
-          strictPluralKeys: false,
-        });
-      }
+    let msg;
+    try {
+      msg = new IntlMessageFormat(sourceString, locale, undefined, { ignoreTag: true });
+    } catch (err) {
+      msg = new IntlMessageFormat(sourceString, undefined, undefined, { ignoreTag: true });
     }
-    const msg = MF[locale].compile(sourceString);
-    return msg(params);
+    return msg.format(params);
   }
 }


### PR DESCRIPTION
Related to this [issue](https://github.com/transifex/transifex-javascript/issues/221)
We use this [package](https://github.com/messageformat/messageformat)  for localization. This package [doesn't adhere](https://github.com/messageformat/messageformat/issues/180) to CSP, which is why they need to include 'unsafe-eval'. The library maintainers [propose](https://github.com/messageformat/messageformat/issues/180) using this [alternative library](https://formatjs.io/docs/intl-messageformat/) instead.

The replacement of the library affects this core [method](https://github.com/transifex/transifex-javascript/blob/master/packages/native/src/renderers/MessageFormatRenderer.js).